### PR TITLE
Require PkgConfig if you need to use it

### DIFF
--- a/CMake/FindOpenJPEG.cmake
+++ b/CMake/FindOpenJPEG.cmake
@@ -7,6 +7,7 @@
 #  OPENJPEG_FOUND        - True if OpenJPEG found
 
 # Use pkg_check_modules to determine the paths for OpenJPEG
+find_package(PkgConfig REQUIRED)
 pkg_check_modules(OPENJPEG_PKGCONF libopenjp2)
 
 # Look for the header file


### PR DESCRIPTION
Because I suddenly got the following error in my CI:
`CMake Error at build/DCMTK-src/CMake/FindOpenJPEG.cmake:10 (pkg_check_modules):`
`  Unknown CMake command "pkg_check_modules".`
`Call Stack (most recent call first):`
`  build/DCMTK-src/CMake/3rdparty.cmake:340 (find_package)`
`  build/DCMTK-src/CMake/dcmtkPrepare.cmake:429 (include)`
`  build/DCMTK-src/CMakeLists.txt:17 (include)`