### PR TITLE
Added support for Stdin and Stdout streams to the toolkit

### DIFF
--- a/dcmdata/apps/mdfconen.cc
+++ b/dcmdata/apps/mdfconen.cc
@@ -541,7 +541,7 @@ int MdfConsoleEngine::startProvidingService()
                 {
                     OFLOG_ERROR(dcmodifyLogger, "couldn't save file: " << result.text());
                     errors++;
-                    if (!no_backup_option && !was_created)
+                    if (!no_backup_option && !was_created && *filename != '-')
                     {
                         result = restoreFile(filename);
                         if (result.bad())
@@ -553,7 +553,7 @@ int MdfConsoleEngine::startProvidingService()
                 }
             }
             // errors occurred and user doesn't want to ignore them:
-            else if (!no_backup_option && !was_created)
+            else if (!no_backup_option && !was_created && *filename != '-')
             {
                 result = restoreFile(filename);
                 if (result.bad())
@@ -587,9 +587,9 @@ OFCondition MdfConsoleEngine::loadFile(const char *filename)
     ds_man->setModifyUNValues(!ignore_un_modifies);
     OFLOG_INFO(dcmodifyLogger, "Processing file: " << filename);
     // load file into dataset manager
-    was_created = !OFStandard::fileExists(filename);
+    //was_created = !OFStandard::fileExists(filename);
     result = ds_man->loadFile(filename, read_mode_option, input_xfer_option, create_if_necessary);
-    if (result.good() && !no_backup_option && !was_created)
+    if (result.good() && !no_backup_option && !was_created && *filename != '-')
         result = backupFile(filename);
     return result;
 }

--- a/dcmdata/apps/mdfconen.cc
+++ b/dcmdata/apps/mdfconen.cc
@@ -541,7 +541,7 @@ int MdfConsoleEngine::startProvidingService()
                 {
                     OFLOG_ERROR(dcmodifyLogger, "couldn't save file: " << result.text());
                     errors++;
-                    if (!no_backup_option && !was_created && OFString(filename) != "-")
+                    if (!no_backup_option && !was_created && strcmp(filename, "-"))
                     {
                         result = restoreFile(filename);
                         if (result.bad())
@@ -553,7 +553,7 @@ int MdfConsoleEngine::startProvidingService()
                 }
             }
             // errors occurred and user doesn't want to ignore them:
-            else if (!no_backup_option && !was_created && OFString(filename) != "-")
+            else if (!no_backup_option && !was_created && strcmp(filename, "-"))
             {
                 result = restoreFile(filename);
                 if (result.bad())
@@ -589,7 +589,7 @@ OFCondition MdfConsoleEngine::loadFile(const char *filename)
     // load file into dataset manager
     was_created = !OFStandard::fileExists(filename);
     result = ds_man->loadFile(filename, read_mode_option, input_xfer_option, create_if_necessary);
-    if (result.good() && !no_backup_option && !was_created && OFString(filename) != "-")
+    if (result.good() && !no_backup_option && !was_created && strcmp(filename, "-"))
         result = backupFile(filename);
     return result;
 }

--- a/dcmdata/apps/mdfconen.cc
+++ b/dcmdata/apps/mdfconen.cc
@@ -587,7 +587,7 @@ OFCondition MdfConsoleEngine::loadFile(const char *filename)
     ds_man->setModifyUNValues(!ignore_un_modifies);
     OFLOG_INFO(dcmodifyLogger, "Processing file: " << filename);
     // load file into dataset manager
-    //was_created = !OFStandard::fileExists(filename);
+    was_created = !OFStandard::fileExists(filename);
     result = ds_man->loadFile(filename, read_mode_option, input_xfer_option, create_if_necessary);
     if (result.good() && !no_backup_option && !was_created && *filename != '-')
         result = backupFile(filename);

--- a/dcmdata/apps/mdfconen.cc
+++ b/dcmdata/apps/mdfconen.cc
@@ -541,7 +541,7 @@ int MdfConsoleEngine::startProvidingService()
                 {
                     OFLOG_ERROR(dcmodifyLogger, "couldn't save file: " << result.text());
                     errors++;
-                    if (!no_backup_option && !was_created && *filename != '-')
+                    if (!no_backup_option && !was_created && OFString(filename) != "-")
                     {
                         result = restoreFile(filename);
                         if (result.bad())
@@ -553,7 +553,7 @@ int MdfConsoleEngine::startProvidingService()
                 }
             }
             // errors occurred and user doesn't want to ignore them:
-            else if (!no_backup_option && !was_created && *filename != '-')
+            else if (!no_backup_option && !was_created && OFString(filename) != "-")
             {
                 result = restoreFile(filename);
                 if (result.bad())
@@ -589,7 +589,7 @@ OFCondition MdfConsoleEngine::loadFile(const char *filename)
     // load file into dataset manager
     was_created = !OFStandard::fileExists(filename);
     result = ds_man->loadFile(filename, read_mode_option, input_xfer_option, create_if_necessary);
-    if (result.good() && !no_backup_option && !was_created && *filename != '-')
+    if (result.good() && !no_backup_option && !was_created && OFString(filename) != "-")
         result = backupFile(filename);
     return result;
 }

--- a/dcmdata/apps/mdfdsman.cc
+++ b/dcmdata/apps/mdfdsman.cc
@@ -57,7 +57,7 @@ OFCondition MdfDatasetManager::loadFile(const char *file_name,
 
     // load file into dfile if it exists
     OFLOG_INFO(mdfdsmanLogger, "Loading file into dataset manager: " << file_name);
-    if (OFStandard::fileExists(file_name) || OFString(file_name) == "-")
+    if (OFStandard::fileExists(file_name) || (strcmp(file_name, "-") == 0))
     {
       cond = dfile->loadFile(file_name, xfer, EGL_noChange, DCM_MaxReadLength, readMode);
     }

--- a/dcmdata/apps/mdfdsman.cc
+++ b/dcmdata/apps/mdfdsman.cc
@@ -57,7 +57,7 @@ OFCondition MdfDatasetManager::loadFile(const char *file_name,
 
     // load file into dfile if it exists
     OFLOG_INFO(mdfdsmanLogger, "Loading file into dataset manager: " << file_name);
-    if (OFStandard::fileExists(file_name))
+    if (OFStandard::fileExists(file_name) || *file_name == '-')
     {
       cond = dfile->loadFile(file_name, xfer, EGL_noChange, DCM_MaxReadLength, readMode);
     }

--- a/dcmdata/apps/mdfdsman.cc
+++ b/dcmdata/apps/mdfdsman.cc
@@ -57,7 +57,7 @@ OFCondition MdfDatasetManager::loadFile(const char *file_name,
 
     // load file into dfile if it exists
     OFLOG_INFO(mdfdsmanLogger, "Loading file into dataset manager: " << file_name);
-    if (OFStandard::fileExists(file_name) || *file_name == '-')
+    if (OFStandard::fileExists(file_name) || OFString(file_name) == "-")
     {
       cond = dfile->loadFile(file_name, xfer, EGL_noChange, DCM_MaxReadLength, readMode);
     }

--- a/dcmdata/include/dcmtk/dcmdata/dcistrmf.h
+++ b/dcmdata/include/dcmtk/dcmdata/dcistrmf.h
@@ -25,7 +25,7 @@
 
 #include "dcmtk/config/osconfig.h"
 #include "dcmtk/dcmdata/dcistrma.h"
-#include <vector>
+#include "dcmtk/ofstd/ofvector.h"
 
 /** producer class that reads data from a plain file.
  */
@@ -391,7 +391,7 @@ public:
 
 private:
 
-  std::vector<char> arr;
+  OFVector<char> arr;
 
   offile_off_t position;
  

--- a/dcmdata/include/dcmtk/dcmdata/dcostrmf.h
+++ b/dcmdata/include/dcmtk/dcmdata/dcostrmf.h
@@ -139,4 +139,113 @@ private:
 };
 
 
+/** consumer class that stores data in a plain file.
+ */
+class DCMTK_DCMDATA_EXPORT DcmStdoutConsumer: public DcmConsumer
+{
+public:
+  /** constructor
+   *  @param filename name of file to be created (may contain wide chars
+   *    if support enabled)
+   */
+  DcmStdoutConsumer(const OFFilename &filename);
+
+  /** constructor
+   *  @param file structure, file must already be open for writing
+   */
+  DcmStdoutConsumer(FILE *file);
+
+  /// destructor
+  virtual ~DcmStdoutConsumer();
+
+  /** returns the status of the consumer. Unless the status is good,
+   *  the consumer will not permit any operation.
+   *  @return status, true if good
+   */
+  virtual OFBool good() const;
+
+  /** returns the status of the consumer as an OFCondition object.
+   *  Unless the status is good, the consumer will not permit any operation.
+   *  @return status, EC_Normal if good
+   */
+  virtual OFCondition status() const;
+
+  /** returns true if the consumer is flushed, i.e. has no more data
+   *  pending in it's internal state that needs to be flushed before
+   *  the stream is closed.
+   *  @return true if consumer is flushed, false otherwise
+   */
+  virtual OFBool isFlushed() const;
+
+  /** returns the minimum number of bytes that can be written with the
+   *  next call to write(). The DcmObject write methods rely on avail
+   *  to return a value > 0 if there is no I/O suspension since certain
+   *  data such as tag and length are only written "en bloc", i.e. all
+   *  or nothing.
+   *  @return minimum of space available in consumer
+   */
+  virtual offile_off_t avail() const;
+
+  /** processes as many bytes as possible from the given input block.
+   *  @param buf pointer to memory block, must not be NULL
+   *  @param buflen length of memory block
+   *  @return number of bytes actually processed.
+   */
+  virtual offile_off_t write(const void *buf, offile_off_t buflen);
+
+  /** instructs the consumer to flush its internal content until
+   *  either the consumer becomes "flushed" or I/O suspension occurs.
+   *  After a call to flush(), a call to write() will produce undefined
+   *  behaviour.
+   */
+  virtual void flush();
+
+private:
+
+  /// private unimplemented copy constructor
+  DcmStdoutConsumer(const DcmStdoutConsumer&);
+
+  /// private unimplemented copy assignment operator
+  DcmStdoutConsumer& operator=(const DcmStdoutConsumer&);
+
+  /// the file we're actually writing to
+  OFFile file_;
+
+  /// status
+  OFCondition status_;
+};
+
+
+/** output stream that writes into a plain file
+ */
+class DCMTK_DCMDATA_EXPORT DcmStdoutStream: public DcmOutputStream
+{
+public:
+  /** constructor
+   *  @param filename name of file to be created (may contain wide chars
+   *    if support enabled)
+   */
+  DcmStdoutStream(const OFFilename &filename);
+
+  /** constructor
+   *  @param file structure, file must already be open for writing
+   */
+  DcmStdoutStream(FILE *file);
+
+  /// destructor
+  virtual ~DcmStdoutStream();
+
+private:
+
+  /// private unimplemented copy constructor
+  DcmStdoutStream(const DcmStdoutStream&);
+
+  /// private unimplemented copy assignment operator
+  DcmStdoutStream& operator=(const DcmStdoutStream&);
+
+  /// the final consumer of the filter chain
+  DcmStdoutConsumer consumer_;
+};
+
+
 #endif

--- a/dcmdata/include/dcmtk/dcmdata/dcostrmf.h
+++ b/dcmdata/include/dcmtk/dcmdata/dcostrmf.h
@@ -139,7 +139,7 @@ private:
 };
 
 
-/** consumer class that stores data in a plain file.
+/** consumer class that writes to standard output.
  */
 class DCMTK_DCMDATA_EXPORT DcmStdoutConsumer: public DcmConsumer
 {
@@ -216,7 +216,7 @@ private:
 };
 
 
-/** output stream that writes into a plain file
+/** output stream that writes to standard output
  */
 class DCMTK_DCMDATA_EXPORT DcmStdoutStream: public DcmOutputStream
 {

--- a/dcmdata/libsrc/dcdatset.cc
+++ b/dcmdata/libsrc/dcdatset.cc
@@ -437,6 +437,7 @@ OFCondition DcmDataset::readUntilTag(DcmInputStream &inStream,
         }
         /* pass processing the task to class DcmItem */
         if (errorFlag.good())
+
             errorFlag = DcmItem::readUntilTag(inStream, OriginalXfer, glenc, maxReadLength, stopParsingAtElement);
 
     }
@@ -647,24 +648,47 @@ OFCondition DcmDataset::loadFileUntilTag(const OFFilename &fileName,
     /* check parameters first */
     if (!fileName.isEmpty())
     {
-        /* open file for input */
-        DcmInputFileStream fileStream(fileName);
+        if (*fileName.getCharPointer() == '-')
+	{
+            /* open file for input */
+            DcmStdinStream fileStream(fileName);
 
-        /* check stream status */
-        l_error = fileStream.status();
+            /* check stream status */
+            l_error = fileStream.status();
 
-        if (l_error.good())
-        {
-            /* clear this object */
-            l_error = clear();
             if (l_error.good())
             {
-                /* read data from file */
-                transferInit();
-                l_error = readUntilTag(fileStream, readXfer, groupLength, maxReadLength, stopParsingAtElement);
-                transferEnd();
+                /* clear this object */
+                l_error = clear();
+                if (l_error.good())
+                {
+                    /* read data from file */
+                    transferInit();
+                    l_error = readUntilTag(fileStream, readXfer, groupLength, maxReadLength, stopParsingAtElement);
+                    transferEnd();
+                }
             }
-        }
+	} else {
+	     /* open file for input */
+            DcmInputFileStream fileStream(fileName);
+
+            /* check stream status */
+            l_error = fileStream.status();
+
+            if (l_error.good())
+            {
+                /* clear this object */
+                l_error = clear();
+                if (l_error.good())
+                {
+                    /* read data from file */
+                    transferInit();
+                    l_error = readUntilTag(fileStream, readXfer, groupLength, maxReadLength, stopParsingAtElement);
+                    transferEnd();
+                }
+            }
+	}
+
     }
     return l_error;
 }
@@ -682,19 +706,37 @@ OFCondition DcmDataset::saveFile(const OFFilename &fileName,
     /* check parameters first */
     if (!fileName.isEmpty())
     {
-        DcmWriteCache wcache;
-        /* open file for output */
-        DcmOutputFileStream fileStream(fileName);
+	DcmWriteCache wcache;
 
-        /* check stream status */
-        l_error = fileStream.status();
-        if (l_error.good())
-        {
-            /* write data to file */
-            transferInit();
-            l_error = write(fileStream, writeXfer, encodingType, &wcache, groupLength, padEncoding, padLength, subPadLength);
-            transferEnd();
-        }
+	if (*fileName.getCharPointer() == '-')
+	{
+            /* open file for output */
+            DcmStdoutStream fileStream(fileName);
+
+            /* check stream status */
+            l_error = fileStream.status();
+            if (l_error.good())
+            {
+                /* write data to file */
+                transferInit();
+                l_error = write(fileStream, writeXfer, encodingType, &wcache, groupLength, padEncoding, padLength, subPadLength);
+                transferEnd();
+            }
+	} else {
+	    /* open file for output */
+            DcmOutputFileStream fileStream(fileName);
+
+            /* check stream status */
+            l_error = fileStream.status();
+            if (l_error.good())
+            {
+                /* write data to file */
+                transferInit();
+                l_error = write(fileStream, writeXfer, encodingType, &wcache, groupLength, padEncoding, padLength, subPadLength);
+                transferEnd();
+            }
+	}
+
     }
     return l_error;
 }

--- a/dcmdata/libsrc/dcdatset.cc
+++ b/dcmdata/libsrc/dcdatset.cc
@@ -648,7 +648,7 @@ OFCondition DcmDataset::loadFileUntilTag(const OFFilename &fileName,
     if (!fileName.isEmpty())
     {
 		DcmInputStream *fileStream;
-		if (*fileName.getCharPointer() == '-')
+		if (OFString(fileName.getCharPointer()) == "-")
 		{
 			/* use stdin stream */
 			fileStream = new DcmStdinStream(fileName);
@@ -692,7 +692,7 @@ OFCondition DcmDataset::saveFile(const OFFilename &fileName,
 		DcmWriteCache wcache;
 		DcmOutputStream *fileStream;
 
-		if (*fileName.getCharPointer() == '-')
+		if (OFString(fileName.getCharPointer()) == "-")
 		{
 			/* use stdout stream */
 			fileStream = new DcmStdoutStream(fileName);

--- a/dcmdata/libsrc/dcdatset.cc
+++ b/dcmdata/libsrc/dcdatset.cc
@@ -647,33 +647,33 @@ OFCondition DcmDataset::loadFileUntilTag(const OFFilename &fileName,
     /* check parameters first */
     if (!fileName.isEmpty())
     {
-		DcmInputStream *fileStream;
-		if (fileName.isStandardStream())
-		{
-			/* use stdin stream */
-			fileStream = new DcmStdinStream(fileName);
-		} else {
-			/* open file for input */
-			fileStream = new DcmInputFileStream(fileName);
-		}
-		/* check stream status */
-		l_error = fileStream->status();
+        DcmInputStream *fileStream;
+        if (fileName.isStandardStream())
+        {
+            /* use stdin stream */
+            fileStream = new DcmStdinStream(fileName);
+        } else {
+            /* open file for input */
+            fileStream = new DcmInputFileStream(fileName);
+        }
+        /* check stream status */
+        l_error = fileStream->status();
 
-		if (l_error.good())
-		{
-			/* clear this object */
-			l_error = clear();
-			if (l_error.good())
-			{
-				/* read data from file */
-				transferInit();
-				l_error = readUntilTag(*fileStream, readXfer, groupLength, maxReadLength, stopParsingAtElement);
-				transferEnd();
-			}
-		}
-		delete fileStream;
-	}
-	return l_error;
+        if (l_error.good())
+        {
+            /* clear this object */
+            l_error = clear();
+            if (l_error.good())
+            {
+                /* read data from file */
+                transferInit();
+                l_error = readUntilTag(*fileStream, readXfer, groupLength, maxReadLength, stopParsingAtElement);
+                transferEnd();
+            } 
+        }
+        delete fileStream;
+    }
+    return l_error;
 }
 
 
@@ -689,29 +689,29 @@ OFCondition DcmDataset::saveFile(const OFFilename &fileName,
     /* check parameters first */
     if (!fileName.isEmpty())
     {
-		DcmWriteCache wcache;
-		DcmOutputStream *fileStream;
+        DcmWriteCache wcache;
+        DcmOutputStream *fileStream;
 
-		if (fileName.isStandardStream())
-		{
-			/* use stdout stream */
-			fileStream = new DcmStdoutStream(fileName);
-		} else {
-			/* open file for output */
-			fileStream = new DcmOutputFileStream(fileName);
-		}
-		/* check stream status */
-		l_error = fileStream->status();
-		if (l_error.good())
-		{
-			/* write data to file */
-			transferInit();
-			l_error = write(*fileStream, writeXfer, encodingType, &wcache, groupLength, padEncoding, padLength, subPadLength);
-			transferEnd();
-		}
-		delete fileStream;
-	}
-	return l_error;
+        if (fileName.isStandardStream())
+        {
+            /* use stdout stream */
+            fileStream = new DcmStdoutStream(fileName);
+        } else {
+            /* open file for output */
+            fileStream = new DcmOutputFileStream(fileName);
+        }
+        /* check stream status */
+        l_error = fileStream->status();
+        if (l_error.good())
+        {
+            /* write data to file */
+            transferInit();
+            l_error = write(*fileStream, writeXfer, encodingType, &wcache, groupLength, padEncoding, padLength, subPadLength);
+            transferEnd();
+        }
+        delete fileStream;
+    }
+    return l_error;
 }
 
 

--- a/dcmdata/libsrc/dcdatset.cc
+++ b/dcmdata/libsrc/dcdatset.cc
@@ -647,13 +647,13 @@ OFCondition DcmDataset::loadFileUntilTag(const OFFilename &fileName,
     /* check parameters first */
     if (!fileName.isEmpty())
     {
-	DcmInputStream *fileStream;
+        DcmInputStream *fileStream;
         if (*fileName.getCharPointer() == '-')
 	{
             /* use stdin stream */
             fileStream = new DcmStdinStream(fileName);
 	} else {
-	     /* open file for input */
+            /* open file for input */
             fileStream = new DcmInputFileStream(fileName);
 	}
         /* check stream status */
@@ -697,7 +697,7 @@ OFCondition DcmDataset::saveFile(const OFFilename &fileName,
             /* use stdout stream */
             fileStream = new DcmStdoutStream(fileName);
 	} else {
-	    /* open file for output */
+            /* open file for output */
             fileStream = new DcmOutputFileStream(fileName);
 	}
         /* check stream status */

--- a/dcmdata/libsrc/dcdatset.cc
+++ b/dcmdata/libsrc/dcdatset.cc
@@ -437,7 +437,6 @@ OFCondition DcmDataset::readUntilTag(DcmInputStream &inStream,
         }
         /* pass processing the task to class DcmItem */
         if (errorFlag.good())
-
             errorFlag = DcmItem::readUntilTag(inStream, OriginalXfer, glenc, maxReadLength, stopParsingAtElement);
 
     }

--- a/dcmdata/libsrc/dcdatset.cc
+++ b/dcmdata/libsrc/dcdatset.cc
@@ -647,33 +647,33 @@ OFCondition DcmDataset::loadFileUntilTag(const OFFilename &fileName,
     /* check parameters first */
     if (!fileName.isEmpty())
     {
-        DcmInputStream *fileStream;
-        if (*fileName.getCharPointer() == '-')
-	{
-            /* use stdin stream */
-            fileStream = new DcmStdinStream(fileName);
-	} else {
-            /* open file for input */
-            fileStream = new DcmInputFileStream(fileName);
-	}
-        /* check stream status */
-        l_error = fileStream->status();
+		DcmInputStream *fileStream;
+		if (*fileName.getCharPointer() == '-')
+		{
+			/* use stdin stream */
+			fileStream = new DcmStdinStream(fileName);
+		} else {
+			/* open file for input */
+			fileStream = new DcmInputFileStream(fileName);
+		}
+		/* check stream status */
+		l_error = fileStream->status();
 
-        if (l_error.good())
-        {
-            /* clear this object */
-            l_error = clear();
-            if (l_error.good())
-            {
-                /* read data from file */
-                transferInit();
-                l_error = readUntilTag(*fileStream, readXfer, groupLength, maxReadLength, stopParsingAtElement);
-                transferEnd();
-            }
-        }
-	delete fileStream;
-    }
-    return l_error;
+		if (l_error.good())
+		{
+			/* clear this object */
+			l_error = clear();
+			if (l_error.good())
+			{
+				/* read data from file */
+				transferInit();
+				l_error = readUntilTag(*fileStream, readXfer, groupLength, maxReadLength, stopParsingAtElement);
+				transferEnd();
+			}
+		}
+		delete fileStream;
+	}
+	return l_error;
 }
 
 
@@ -689,29 +689,29 @@ OFCondition DcmDataset::saveFile(const OFFilename &fileName,
     /* check parameters first */
     if (!fileName.isEmpty())
     {
-	DcmWriteCache wcache;
-	DcmOutputStream *fileStream;
+		DcmWriteCache wcache;
+		DcmOutputStream *fileStream;
 
-	if (*fileName.getCharPointer() == '-')
-	{
-            /* use stdout stream */
-            fileStream = new DcmStdoutStream(fileName);
-	} else {
-            /* open file for output */
-            fileStream = new DcmOutputFileStream(fileName);
+		if (*fileName.getCharPointer() == '-')
+		{
+			/* use stdout stream */
+			fileStream = new DcmStdoutStream(fileName);
+		} else {
+			/* open file for output */
+			fileStream = new DcmOutputFileStream(fileName);
+		}
+		/* check stream status */
+		l_error = fileStream->status();
+		if (l_error.good())
+		{
+			/* write data to file */
+			transferInit();
+			l_error = write(*fileStream, writeXfer, encodingType, &wcache, groupLength, padEncoding, padLength, subPadLength);
+			transferEnd();
+		}
+		delete fileStream;
 	}
-        /* check stream status */
-        l_error = fileStream->status();
-        if (l_error.good())
-        {
-            /* write data to file */
-            transferInit();
-            l_error = write(*fileStream, writeXfer, encodingType, &wcache, groupLength, padEncoding, padLength, subPadLength);
-            transferEnd();
-        }
-	delete fileStream;
-    }
-    return l_error;
+	return l_error;
 }
 
 

--- a/dcmdata/libsrc/dcdatset.cc
+++ b/dcmdata/libsrc/dcdatset.cc
@@ -648,7 +648,7 @@ OFCondition DcmDataset::loadFileUntilTag(const OFFilename &fileName,
     if (!fileName.isEmpty())
     {
 		DcmInputStream *fileStream;
-		if (OFString(fileName.getCharPointer()) == "-")
+		if (fileName.isStandardStream())
 		{
 			/* use stdin stream */
 			fileStream = new DcmStdinStream(fileName);
@@ -692,7 +692,7 @@ OFCondition DcmDataset::saveFile(const OFFilename &fileName,
 		DcmWriteCache wcache;
 		DcmOutputStream *fileStream;
 
-		if (OFString(fileName.getCharPointer()) == "-")
+		if (fileName.isStandardStream())
 		{
 			/* use stdout stream */
 			fileStream = new DcmStdoutStream(fileName);

--- a/dcmdata/libsrc/dcfilefo.cc
+++ b/dcmdata/libsrc/dcfilefo.cc
@@ -51,7 +51,6 @@
 #include "dcmtk/dcmdata/dcwcache.h"    /* for class DcmWriteCache */
 #include "dcmtk/dcmdata/dcjson.h"
 
-
 // ********************************
 
 
@@ -746,9 +745,12 @@ OFCondition DcmFileFormat::readUntilTag(DcmInputStream &inStream,
             }
             if (errorFlag.good() && (!metaInfo || metaInfo->transferState() == ERW_ready))
             {
+
                 dataset = getDataset();
+
                 if (dataset == NULL && getTransferState() == ERW_init)
                 {
+
                     dataset = new DcmDataset();
                     itemList->seek (ELP_first);
                     itemList->insert(dataset, ELP_next);
@@ -764,6 +766,7 @@ OFCondition DcmFileFormat::readUntilTag(DcmInputStream &inStream,
                     }
                 }
             }
+	    
         }
         if (getTransferState() == ERW_init)
             setTransferState(ERW_inWork);
@@ -771,6 +774,7 @@ OFCondition DcmFileFormat::readUntilTag(DcmInputStream &inStream,
         if (dataset && dataset->transferState() == ERW_ready)
             setTransferState(ERW_ready);
     }
+    
     return errorFlag;
 }  // DcmFileFormat::readUntilTag()
 
@@ -907,30 +911,60 @@ OFCondition DcmFileFormat::loadFileUntilTag(
 
     OFCondition l_error = EC_InvalidFilename;
     /* check parameters first */
-    if (!fileName.isEmpty())
-    {
+    if (!fileName.isEmpty()){
         /* open file for input */
-        DcmInputFileStream fileStream(fileName);
-        /* check stream status */
-        l_error = fileStream.status();
-        if (l_error.good())
-        {
-            /* clear this object */
-            l_error = clear();
-            if (l_error.good())
-            {
-                /* save old value */
-                const E_FileReadMode oldMode = FileReadMode;
-                FileReadMode = readMode;
-                /* read data from file */
-                transferInit();
-                l_error = readUntilTag(fileStream, readXfer, groupLength, maxReadLength, stopParsingAtElement);
-                transferEnd();
-                /* restore old value */
-                FileReadMode = oldMode;
-            }
-        }
+
+	if (*fileName.getCharPointer() == '-'){
+		DcmStdinStream fileStream(fileName);
+	     
+	
+        	/* check stream status */
+        	l_error = fileStream.status();
+        	if (l_error.good())
+        	{
+            		/* clear this object */
+            		l_error = clear();
+            		if (l_error.good())
+            		{
+                		/* save old value */
+                		const E_FileReadMode oldMode = FileReadMode;
+                		FileReadMode = readMode;
+                		/* read data from file */
+                		transferInit();
+                		l_error = readUntilTag(fileStream, readXfer, groupLength, maxReadLength, stopParsingAtElement);
+                		transferEnd();
+                		/* restore old value */
+                		FileReadMode = oldMode;
+            		}
+        	}
+	 } else {
+		DcmInputFileStream fileStream(fileName);
+	     
+	
+        	/* check stream status */
+        	l_error = fileStream.status();
+        	if (l_error.good())
+        	{
+            		/* clear this object */
+            		l_error = clear();
+            		if (l_error.good())
+            		{
+                		/* save old value */
+                		const E_FileReadMode oldMode = FileReadMode;
+                		FileReadMode = readMode;
+                		/* read data from file */
+                		transferInit();
+                		l_error = readUntilTag(fileStream, readXfer, groupLength, maxReadLength, stopParsingAtElement);
+                		transferEnd();
+                		/* restore old value */
+                		FileReadMode = oldMode;
+            		}
+        	}
+
+	 }
+    
     }
+
     return l_error;
 }
 
@@ -954,20 +988,35 @@ OFCondition DcmFileFormat::saveFile(const OFFilename &fileName,
     if (!fileName.isEmpty())
     {
         DcmWriteCache wcache;
+	if (*fileName.getCharPointer() == '-'){
+            /* open file for output */
+            DcmStdoutStream fileStream(fileName);
 
-        /* open file for output */
-        DcmOutputFileStream fileStream(fileName);
-
-        /* check stream status */
-        l_error = fileStream.status();
-        if (l_error.good())
-        {
-            /* write data to file */
-            transferInit();
-            l_error = write(fileStream, writeXfer, encodingType, &wcache, groupLength,
+            /* check stream status */
+            l_error = fileStream.status();
+            if (l_error.good())
+            {
+                /* write data to file */
+            	transferInit();
+            	l_error = write(fileStream, writeXfer, encodingType, &wcache, groupLength,
                 padEncoding, padLength, subPadLength, 0 /*instanceLength*/, writeMode);
-            transferEnd();
-        }
+            	transferEnd();
+            }
+	} else {
+	    /* open file for output */
+            DcmOutputFileStream fileStream(fileName);
+
+            /* check stream status */
+            l_error = fileStream.status();
+            if (l_error.good())
+            {
+                /* write data to file */
+            	transferInit();
+            	l_error = write(fileStream, writeXfer, encodingType, &wcache, groupLength,
+                padEncoding, padLength, subPadLength, 0 /*instanceLength*/, writeMode);
+            	transferEnd();
+            }
+	}
     }
     return l_error;
 }

--- a/dcmdata/libsrc/dcfilefo.cc
+++ b/dcmdata/libsrc/dcfilefo.cc
@@ -911,7 +911,7 @@ OFCondition DcmFileFormat::loadFileUntilTag(
 	DcmInputStream *fileStream;
 	if (*fileName.getCharPointer() == '-')
 	{
-	    /* use stdin stream */
+            /* use stdin stream */
 	    fileStream = new DcmStdinStream(fileName);
 	} else {
 	    /* open file for output */
@@ -964,13 +964,13 @@ OFCondition DcmFileFormat::saveFile(const OFFilename &fileName,
 	DcmOutputStream *fileStream;
 	if (*fileName.getCharPointer() == '-')
 	{
-	    /* use stdout stream */
+            /* use stdout stream */
             fileStream = new DcmStdoutStream(fileName);
 	} else {
-	    /* open file for output */
+            /* open file for output */
             fileStream = new DcmOutputFileStream(fileName);
 	}
-            /* check stream status */
+        /* check stream status */
         l_error = fileStream->status();
         if (l_error.good())
         {

--- a/dcmdata/libsrc/dcfilefo.cc
+++ b/dcmdata/libsrc/dcfilefo.cc
@@ -745,12 +745,9 @@ OFCondition DcmFileFormat::readUntilTag(DcmInputStream &inStream,
             }
             if (errorFlag.good() && (!metaInfo || metaInfo->transferState() == ERW_ready))
             {
-
                 dataset = getDataset();
-
                 if (dataset == NULL && getTransferState() == ERW_init)
                 {
-
                     dataset = new DcmDataset();
                     itemList->seek (ELP_first);
                     itemList->insert(dataset, ELP_next);
@@ -766,7 +763,6 @@ OFCondition DcmFileFormat::readUntilTag(DcmInputStream &inStream,
                     }
                 }
             }
-	    
         }
         if (getTransferState() == ERW_init)
             setTransferState(ERW_inWork);
@@ -774,7 +770,6 @@ OFCondition DcmFileFormat::readUntilTag(DcmInputStream &inStream,
         if (dataset && dataset->transferState() == ERW_ready)
             setTransferState(ERW_ready);
     }
-    
     return errorFlag;
 }  // DcmFileFormat::readUntilTag()
 
@@ -911,7 +906,8 @@ OFCondition DcmFileFormat::loadFileUntilTag(
 
     OFCondition l_error = EC_InvalidFilename;
     /* check parameters first */
-    if (!fileName.isEmpty()){
+    if (!fileName.isEmpty())
+    {
         /* open file for input */
 
 	if (*fileName.getCharPointer() == '-'){
@@ -960,11 +956,8 @@ OFCondition DcmFileFormat::loadFileUntilTag(
                 		FileReadMode = oldMode;
             		}
         	}
-
 	 }
-    
     }
-
     return l_error;
 }
 

--- a/dcmdata/libsrc/dcfilefo.cc
+++ b/dcmdata/libsrc/dcfilefo.cc
@@ -909,7 +909,7 @@ OFCondition DcmFileFormat::loadFileUntilTag(
     if (!fileName.isEmpty())
     {
 		DcmInputStream *fileStream;
-		if (OFString(fileName.getCharPointer()) == "-")
+		if (fileName.isStandardStream())
 		{
 			/* use stdin stream */
 			fileStream = new DcmStdinStream(fileName);
@@ -962,7 +962,7 @@ OFCondition DcmFileFormat::saveFile(const OFFilename &fileName,
     {
         DcmWriteCache wcache;
 		DcmOutputStream *fileStream;
-		if (OFString(fileName.getCharPointer()) == "-")
+		if (fileName.isStandardStream())
 		{
 			/* use stdout stream */
 			fileStream = new DcmStdoutStream(fileName);

--- a/dcmdata/libsrc/dcfilefo.cc
+++ b/dcmdata/libsrc/dcfilefo.cc
@@ -908,37 +908,37 @@ OFCondition DcmFileFormat::loadFileUntilTag(
     /* check parameters first */
     if (!fileName.isEmpty())
     {
-	DcmInputStream *fileStream;
-	if (*fileName.getCharPointer() == '-')
-	{
-            /* use stdin stream */
-	    fileStream = new DcmStdinStream(fileName);
-	} else {
-	    /* open file for output */
-	    fileStream = new DcmInputFileStream(fileName);
+		DcmInputStream *fileStream;
+		if (*fileName.getCharPointer() == '-')
+		{
+			/* use stdin stream */
+			fileStream = new DcmStdinStream(fileName);
+		} else {
+			/* open file for output */
+			fileStream = new DcmInputFileStream(fileName);
+		}
+		/* check stream status */
+		l_error = fileStream->status();
+		if (l_error.good())
+		{
+			/* clear this object */
+			l_error = clear();
+			if (l_error.good())
+			{
+				/* save old value */
+				const E_FileReadMode oldMode = FileReadMode;
+				FileReadMode = readMode;
+				/* read data from file */
+				transferInit();
+				l_error = readUntilTag(*fileStream, readXfer, groupLength, maxReadLength, stopParsingAtElement);
+				transferEnd();
+				/* restore old value */
+				FileReadMode = oldMode;
+			}
+		}
+		delete fileStream;
 	}
-        /* check stream status */
-        l_error = fileStream->status();
-        if (l_error.good())
-        {
-            /* clear this object */
-            l_error = clear();
-            if (l_error.good())
-            {
-                /* save old value */
-                const E_FileReadMode oldMode = FileReadMode;
-                FileReadMode = readMode;
-                /* read data from file */
-                transferInit();
-                l_error = readUntilTag(*fileStream, readXfer, groupLength, maxReadLength, stopParsingAtElement);
-                transferEnd();
-                /* restore old value */
-                FileReadMode = oldMode;
-            }
-        }
-	delete fileStream;
-    }
-    return l_error;
+	return l_error;
 }
 
 
@@ -961,30 +961,28 @@ OFCondition DcmFileFormat::saveFile(const OFFilename &fileName,
     if (!fileName.isEmpty())
     {
         DcmWriteCache wcache;
-	DcmOutputStream *fileStream;
-	if (*fileName.getCharPointer() == '-')
-	{
-            /* use stdout stream */
-            fileStream = new DcmStdoutStream(fileName);
-	} else {
-            /* open file for output */
-            fileStream = new DcmOutputFileStream(fileName);
-	}
-        /* check stream status */
-        l_error = fileStream->status();
-        if (l_error.good())
-        {
-            /* write data to file */
-            transferInit();
-            l_error = write(*fileStream, writeXfer, encodingType, &wcache, groupLength,
-            padEncoding, padLength, subPadLength, 0 /*instanceLength*/, writeMode);
-            transferEnd();
-        }
+		DcmOutputStream *fileStream;
+		if (*fileName.getCharPointer() == '-')
+		{
+			/* use stdout stream */
+			fileStream = new DcmStdoutStream(fileName);
+		} else {
+			/* open file for output */
+			fileStream = new DcmOutputFileStream(fileName);
+		}
+		/* check stream status */
+		l_error = fileStream->status();
+		if (l_error.good())
+		{
+			/* write data to file */
+			transferInit();
+			l_error = write(*fileStream, writeXfer, encodingType, &wcache, groupLength,
+			padEncoding, padLength, subPadLength, 0 /*instanceLength*/, writeMode);
+			transferEnd();
+		}
 	delete fileStream;
-    }
-
-
-    return l_error;
+	}
+	return l_error;
 }
 
 

--- a/dcmdata/libsrc/dcfilefo.cc
+++ b/dcmdata/libsrc/dcfilefo.cc
@@ -908,37 +908,37 @@ OFCondition DcmFileFormat::loadFileUntilTag(
     /* check parameters first */
     if (!fileName.isEmpty())
     {
-		DcmInputStream *fileStream;
-		if (fileName.isStandardStream())
-		{
-			/* use stdin stream */
-			fileStream = new DcmStdinStream(fileName);
-		} else {
-			/* open file for output */
-			fileStream = new DcmInputFileStream(fileName);
-		}
-		/* check stream status */
-		l_error = fileStream->status();
-		if (l_error.good())
-		{
-			/* clear this object */
-			l_error = clear();
-			if (l_error.good())
-			{
-				/* save old value */
-				const E_FileReadMode oldMode = FileReadMode;
-				FileReadMode = readMode;
-				/* read data from file */
-				transferInit();
-				l_error = readUntilTag(*fileStream, readXfer, groupLength, maxReadLength, stopParsingAtElement);
-				transferEnd();
-				/* restore old value */
-				FileReadMode = oldMode;
-			}
-		}
-		delete fileStream;
-	}
-	return l_error;
+        DcmInputStream *fileStream;
+        if (fileName.isStandardStream())
+        {
+            /* use stdin stream */
+            fileStream = new DcmStdinStream(fileName);
+        } else {
+            /* open file for output */
+            fileStream = new DcmInputFileStream(fileName);
+        }
+        /* check stream status */
+        l_error = fileStream->status();
+        if (l_error.good())
+        {
+            /* clear this object */
+            l_error = clear();
+            if (l_error.good())
+            {
+                /* save old value */
+                const E_FileReadMode oldMode = FileReadMode;
+                FileReadMode = readMode;
+                /* read data from file */
+                transferInit();
+                l_error = readUntilTag(*fileStream, readXfer, groupLength, maxReadLength, stopParsingAtElement);
+                transferEnd();
+                /* restore old value */
+                FileReadMode = oldMode;
+            }
+        }
+        delete fileStream;
+    }
+    return l_error;
 }
 
 
@@ -961,28 +961,28 @@ OFCondition DcmFileFormat::saveFile(const OFFilename &fileName,
     if (!fileName.isEmpty())
     {
         DcmWriteCache wcache;
-		DcmOutputStream *fileStream;
-		if (fileName.isStandardStream())
-		{
-			/* use stdout stream */
-			fileStream = new DcmStdoutStream(fileName);
-		} else {
-			/* open file for output */
-			fileStream = new DcmOutputFileStream(fileName);
-		}
-		/* check stream status */
-		l_error = fileStream->status();
-		if (l_error.good())
-		{
-			/* write data to file */
-			transferInit();
-			l_error = write(*fileStream, writeXfer, encodingType, &wcache, groupLength,
-			padEncoding, padLength, subPadLength, 0 /*instanceLength*/, writeMode);
-			transferEnd();
-		}
-		delete fileStream;
-	}
-	return l_error;
+        DcmOutputStream *fileStream;
+        if (fileName.isStandardStream())
+        {
+            /* use stdout stream */
+            fileStream = new DcmStdoutStream(fileName);
+        } else {
+            /* open file for output */
+            fileStream = new DcmOutputFileStream(fileName);
+        }
+        /* check stream status */
+        l_error = fileStream->status();
+        if (l_error.good())
+        {
+            /* write data to file */
+            transferInit();
+            l_error = write(*fileStream, writeXfer, encodingType, &wcache, groupLength,
+            padEncoding, padLength, subPadLength, 0 /*instanceLength*/, writeMode);
+            transferEnd();
+        }
+        delete fileStream;
+    }
+    return l_error;
 }
 
 

--- a/dcmdata/libsrc/dcfilefo.cc
+++ b/dcmdata/libsrc/dcfilefo.cc
@@ -980,7 +980,7 @@ OFCondition DcmFileFormat::saveFile(const OFFilename &fileName,
 			padEncoding, padLength, subPadLength, 0 /*instanceLength*/, writeMode);
 			transferEnd();
 		}
-	delete fileStream;
+		delete fileStream;
 	}
 	return l_error;
 }

--- a/dcmdata/libsrc/dcfilefo.cc
+++ b/dcmdata/libsrc/dcfilefo.cc
@@ -909,7 +909,7 @@ OFCondition DcmFileFormat::loadFileUntilTag(
     if (!fileName.isEmpty())
     {
 		DcmInputStream *fileStream;
-		if (*fileName.getCharPointer() == '-')
+		if (OFString(fileName.getCharPointer()) == "-")
 		{
 			/* use stdin stream */
 			fileStream = new DcmStdinStream(fileName);
@@ -962,7 +962,7 @@ OFCondition DcmFileFormat::saveFile(const OFFilename &fileName,
     {
         DcmWriteCache wcache;
 		DcmOutputStream *fileStream;
-		if (*fileName.getCharPointer() == '-')
+		if (OFString(fileName.getCharPointer()) == "-")
 		{
 			/* use stdout stream */
 			fileStream = new DcmStdoutStream(fileName);

--- a/dcmdata/libsrc/dcistrmf.cc
+++ b/dcmdata/libsrc/dcistrmf.cc
@@ -35,7 +35,6 @@ DcmFileProducer::DcmFileProducer(const OFFilename &filename, offile_off_t offset
 , status_(EC_Normal)
 , size_(0)
 {
-
   if (file_.fopen(filename, "rb"))
   {
      // Get number of bytes in file
@@ -47,7 +46,6 @@ DcmFileProducer::DcmFileProducer(const OFFilename &filename, offile_off_t offset
        file_.getLastErrorString(s);
        status_ = makeOFCondition(OFM_dcmdata, 18, OF_error, s.c_str());
      }
- 
   }
   else
   {
@@ -89,10 +87,9 @@ offile_off_t DcmFileProducer::read(void *buf, offile_off_t buflen)
 {
   offile_off_t result = 0;
   if (status_.good() && file_.open() && buf && buflen)
-  { 
-    result += file_.fread(buf, 1, OFstatic_cast(size_t, buflen));
+  {
+    result = file_.fread(buf, 1, OFstatic_cast(size_t, buflen));
   }
-
   return result;
 }
 
@@ -129,7 +126,6 @@ void DcmFileProducer::putback(offile_off_t num)
     }
     else status_ = EC_PutbackFailed; // tried to putback before start of file
   }
-
 }
 
 

--- a/dcmdata/libsrc/dcistrmf.cc
+++ b/dcmdata/libsrc/dcistrmf.cc
@@ -35,6 +35,7 @@ DcmFileProducer::DcmFileProducer(const OFFilename &filename, offile_off_t offset
 , status_(EC_Normal)
 , size_(0)
 {
+
   if (file_.fopen(filename, "rb"))
   {
      // Get number of bytes in file
@@ -46,6 +47,7 @@ DcmFileProducer::DcmFileProducer(const OFFilename &filename, offile_off_t offset
        file_.getLastErrorString(s);
        status_ = makeOFCondition(OFM_dcmdata, 18, OF_error, s.c_str());
      }
+ 
   }
   else
   {
@@ -87,9 +89,10 @@ offile_off_t DcmFileProducer::read(void *buf, offile_off_t buflen)
 {
   offile_off_t result = 0;
   if (status_.good() && file_.open() && buf && buflen)
-  {
-    result = file_.fread(buf, 1, OFstatic_cast(size_t, buflen));
+  { 
+    result += file_.fread(buf, 1, OFstatic_cast(size_t, buflen));
   }
+
   return result;
 }
 
@@ -126,6 +129,7 @@ void DcmFileProducer::putback(offile_off_t num)
     }
     else status_ = EC_PutbackFailed; // tried to putback before start of file
   }
+
 }
 
 
@@ -256,4 +260,113 @@ DcmInputStream *DcmInputTempFileStreamFactory::create() const
 DcmInputStreamFactory *DcmInputTempFileStreamFactory::clone() const
 {
     return new DcmInputTempFileStreamFactory(*this);
+}
+
+/* ============================================================================== */
+
+// DcmStdinProducer class is responsible for reading the binary data from a Dcm file
+// and is triggered when the filename is '-'
+DcmStdinProducer::DcmStdinProducer(const OFFilename &filename, offile_off_t offset)
+: DcmProducer()
+, file_()
+, status_(EC_Normal)
+, size_(0)
+{
+
+    char ch;
+     // Get the number of bytes in the file
+     while ( std::cin >> std::noskipws >> ch) {
+	     arr.push_back(ch);
+	 
+     }
+     
+     size_ = arr.size();
+
+     position = offset;
+}
+
+DcmStdinProducer::~DcmStdinProducer()
+{
+}
+
+OFBool DcmStdinProducer::good() const
+{
+  return status_.good();
+}
+
+OFCondition DcmStdinProducer::status() const
+{
+  return status_;
+}
+
+OFBool DcmStdinProducer::eos()
+{
+  if (position == arr.size() ) {
+      return OFTrue;
+  }
+  return OFFalse;
+}
+
+offile_off_t DcmStdinProducer::avail()
+{
+  return size_ - 1 - position;
+}
+
+offile_off_t DcmStdinProducer::read(void *buf, offile_off_t buflen)
+{
+  offile_off_t result = 0;
+  if (status_.good() && buf && buflen)
+  { 
+      for (int i = 0; i < OFstatic_cast(size_t, buflen); i++){
+	  if ((position + i) >= size_) {
+	      break;
+	  }
+	  char ch = arr[position + i];
+
+	 *((char*)buf + i) = ch;
+	 result += 1;
+      } 
+  }
+
+  position += result;
+  return result;
+}
+
+offile_off_t DcmStdinProducer::skip(offile_off_t skiplen)
+{
+
+  offile_off_t result = 0;
+  if (status_.good() && skiplen)
+  {
+    result = (size_ - position < skiplen) ? (size_ - position) : skiplen;
+  }
+  position += result;
+  return result;
+}
+
+void DcmStdinProducer::putback(offile_off_t num)
+{
+
+  if (status_.good() && num)
+  {
+ 
+    if (num <= position)
+    {
+      position -= num;
+    }
+    else status_ = EC_PutbackFailed; // tried to putback before start of file
+  }
+}
+
+/* ======================================================================= */
+
+DcmStdinStream::DcmStdinStream(const OFFilename &filename, offile_off_t offset)
+: DcmInputStream(&producer_) // safe because DcmInputStream only stores pointer
+, producer_(filename, offset)
+, filename_(filename)
+{
+}
+
+DcmStdinStream::~DcmStdinStream()
+{
 }

--- a/dcmdata/libsrc/dcistrmf.cc
+++ b/dcmdata/libsrc/dcistrmf.cc
@@ -311,13 +311,13 @@ offile_off_t DcmStdinProducer::read(void *buf, offile_off_t buflen)
   { 
       for (int i = 0; i < OFstatic_cast(size_t, buflen); i++)
       {
-	  if ((position + i) >= size_)
-	  {
-	      break;
-	  }
-      char ch = arr[position + i];
-      *((char*)buf + i) = ch;
-      result += 1;
+          if ((position + i) >= size_)
+          {
+              break;
+          }
+          char ch = arr[position + i];
+          *((char*)buf + i) = ch;
+          result += 1;
       } 
   }
   position += result;
@@ -339,7 +339,6 @@ void DcmStdinProducer::putback(offile_off_t num)
 {
   if (status_.good() && num)
   {
- 
     if (num <= position)
     {
       position -= num;

--- a/dcmdata/libsrc/dcostrmf.cc
+++ b/dcmdata/libsrc/dcostrmf.cc
@@ -194,9 +194,9 @@ offile_off_t DcmStdoutConsumer::write(const void *buf, offile_off_t buflen)
     offile_off_t written;
     const char *buf2 = OFstatic_cast(const char *, buf);
     for (int i=0; i < buflen; i++)
-	{
-	std::cout << *(buf2 + i);
-	result ++;
+    {
+	    std::cout << *(buf2 + i);
+	    result ++;
     }
     std::cout << std::flush;
   }

--- a/dcmdata/libsrc/dcostrmf.cc
+++ b/dcmdata/libsrc/dcostrmf.cc
@@ -80,7 +80,6 @@ offile_off_t DcmFileConsumer::write(const void *buf, offile_off_t buflen)
   if (status_.good() && file_.open() && buf && buflen)
   {
 #ifdef WRITE_VERY_LARGE_CHUNKS
-
     /* This is the old behaviour prior to DCMTK 3.5.5 */
     result = OFstatic_cast(offile_off_t, file_.fwrite(buf, 1, OFstatic_cast(size_t, buflen)));
 #else
@@ -90,7 +89,6 @@ offile_off_t DcmFileConsumer::write(const void *buf, offile_off_t buflen)
      * 32M which should hardly negatively affect performance.
      */
 #define DcmFileConsumer_MAX_CHUNK_SIZE 33554432 /* 32 MByte */
-
     offile_off_t written;
     const char *buf2 = OFstatic_cast(const char *, buf);
     while (buflen > DcmFileConsumer_MAX_CHUNK_SIZE)

--- a/dcmdata/libsrc/dcostrmf.cc
+++ b/dcmdata/libsrc/dcostrmf.cc
@@ -194,8 +194,8 @@ offile_off_t DcmStdoutConsumer::write(const void *buf, offile_off_t buflen)
     offile_off_t written;
     const char *buf2 = OFstatic_cast(const char *, buf);
     for (int i=0; i < buflen; i++)
-    {
-        std::cout << *(buf2 + i);
+	{
+	std::cout << *(buf2 + i);
 	result ++;
     }
     std::cout << std::flush;

--- a/ofstd/include/dcmtk/ofstd/offile.h
+++ b/ofstd/include/dcmtk/ofstd/offile.h
@@ -237,15 +237,12 @@ public:
 #if defined(WIDE_CHAR_FILE_IO_FUNCTONS) && defined(_WIN32)
     if (usesWideChars())
     {
-        if (getWideCharPointer() != NULL)
-        {
-            result = (std::wstring(getWideCharPointer()) == L"-");
-        }
+        result = (wcscmp(getWideCharPointer(), L"-") == 0);
     } else
 #endif
         if (getCharPointer() != NULL)
         {
-            result = (OFString(getCharPointer()) == "-");
+            result = (strcmp(getCharPointer(), "-") == 0);
         }
     return result;
   }

--- a/ofstd/include/dcmtk/ofstd/offile.h
+++ b/ofstd/include/dcmtk/ofstd/offile.h
@@ -227,6 +227,23 @@ public:
   }
 #endif
 
+  /** Uses the filename to determine whether the standard input or output streams
+   *  should be used. Checks for filename = "-" and supports wchar filenames
+   *  @return true if stdin or stdout should be used, false otherwise
+   */
+  OFBool isStandardStream() const
+  {
+	OFBool result = OFFalse;
+#if defined(WIDE_CHAR_FILE_IO_FUNCTONS) && defined(_WIN32)
+	if (usesWideChars())
+	{
+		result = (std::wstring(getWideCharPointer()) == L"-");
+	} else
+#endif
+		result = (OFString(getCharPointer()) == "-");
+	return result;
+  }
+
   /** replace currently stored filename by given value
    *  @param filename filename to be stored (8-bit characters, e.g. UTF-8)
    *  @param convert  convert given filename to wide character encoding as an

--- a/ofstd/include/dcmtk/ofstd/offile.h
+++ b/ofstd/include/dcmtk/ofstd/offile.h
@@ -237,11 +237,17 @@ public:
 #if defined(WIDE_CHAR_FILE_IO_FUNCTONS) && defined(_WIN32)
 	if (usesWideChars())
 	{
-		result = (std::wstring(getWideCharPointer()) == L"-");
+        if (getWideCharPointer() != NULL)
+        {
+		    result = (std::wstring(getWideCharPointer()) == L"-");
+        }
 	} else
 #endif
-		result = (OFString(getCharPointer()) == "-");
-	return result;
+		if (getCharPointer() != NULL)
+        {
+		    result = (OFString(getCharPointer()) == "-");
+	    }
+    return result;
   }
 
   /** replace currently stored filename by given value

--- a/ofstd/include/dcmtk/ofstd/offile.h
+++ b/ofstd/include/dcmtk/ofstd/offile.h
@@ -233,20 +233,20 @@ public:
    */
   OFBool isStandardStream() const
   {
-	OFBool result = OFFalse;
+    OFBool result = OFFalse;
 #if defined(WIDE_CHAR_FILE_IO_FUNCTONS) && defined(_WIN32)
-	if (usesWideChars())
-	{
+    if (usesWideChars())
+    {
         if (getWideCharPointer() != NULL)
         {
-		    result = (std::wstring(getWideCharPointer()) == L"-");
+            result = (std::wstring(getWideCharPointer()) == L"-");
         }
-	} else
+    } else
 #endif
-		if (getCharPointer() != NULL)
+        if (getCharPointer() != NULL)
         {
-		    result = (OFString(getCharPointer()) == "-");
-	    }
+            result = (OFString(getCharPointer()) == "-");
+        }
     return result;
   }
 


### PR DESCRIPTION
I have added support for both standard input streams and standard output streams to read and print DICOM binary data. The stdin and stdout streams are triggered when the input file name or output file name is '-' respectively. 

To make the change I implemented two new classes called DcmStdinStream + DcmStdoutStream which take the place of the usual DcmInputFileStream and DcmOutputFileStream when the input and output file name is '-'. Thus there is some redirection code in dcfilefo.cc and dcdatset.cc in the loadFile and saveFile methods. I also modified mdfconen.cc + mdfdsman.cc to not check that '-' exists as a valid file and to never attempt a backup when reading + writing to stdin + stdout.

This is a preliminary feature so I appreciate any and all feedback you can provide to improve this feature, and I hope this is a feature you would be interested in merging into the toolkit. Thanks!

This feature was sponsored by: Segmed Inc, https://www.segmed.ai