### PR TITLE
Too strong interpretation of PS3.3 / C.7.6.1.1.5 Lossy Image Compression

### DIFF
--- a/dcmdata/include/dcmtk/dcmdata/dccodec.h
+++ b/dcmdata/include/dcmtk/dcmdata/dccodec.h
@@ -129,6 +129,9 @@ public:
    *  @param decompressedColorModel upon successful return, the color model
    *    of the decompressed image (which may be different from the one used
    *    in the compressed images) is returned in this parameter.
+   *  @param isFrameLossless upon successful return, the lossless attribute
+   *    of the decompressed image (which may be different from the one used
+   *    in the transfer syntax) is returned in this parameter.
    *  @return EC_Normal if successful, an error code otherwise.
    */
   virtual OFCondition decodeFrame(
@@ -140,7 +143,8 @@ public:
     Uint32& startFragment,
     void *buffer,
     Uint32 bufSize,
-    OFString& decompressedColorModel) const = 0;
+    OFString& decompressedColorModel,
+    OFBool& isFrameLossless) const = 0;
 
   /** compresses the given uncompressed DICOM image and stores
    *  the result in the given pixSeq element.
@@ -398,6 +402,9 @@ public:
    *  @param decompressedColorModel upon successful return, the color model
    *    of the decompressed image (which may be different from the one used
    *    in the compressed images) is returned in this parameter.
+   *  @param isFrameLossless upon successful return, the lossless attribute
+   *    of the decompressed image (which may be different from the one used
+   *    in the transfer syntax) is returned in this parameter.
    *  @return EC_Normal if successful, an error code otherwise.
    */
   static OFCondition decodeFrame(
@@ -409,7 +416,8 @@ public:
     Uint32& startFragment,
     void *buffer,
     Uint32 bufSize,
-    OFString& decompressedColorModel);
+    OFString& decompressedColorModel,
+    OFBool& isFrameLossless);
 
   /** looks for a codec that is able to encode from the given transfer syntax
    *  and calls the encode() method of the codec.  A read lock on the list of

--- a/dcmdata/include/dcmtk/dcmdata/dcrleccd.h
+++ b/dcmdata/include/dcmtk/dcmdata/dcrleccd.h
@@ -84,6 +84,9 @@ public:
    *  @param decompressedColorModel upon successful return, the color model
    *    of the decompressed image (which may be different from the one used
    *    in the compressed images) is returned in this parameter.
+   *  @param isFrameLossless upon successful return, the lossless attribute
+   *    of the decompressed image (which may be different from the one used
+   *    in the transfer syntax) is returned in this parameter.
    *  @return EC_Normal if successful, an error code otherwise.
    */
   virtual OFCondition decodeFrame(
@@ -95,7 +98,8 @@ public:
     Uint32& startFragment,
     void *buffer,
     Uint32 bufSize,
-    OFString& decompressedColorModel) const;
+    OFString& decompressedColorModel,
+    OFBool& isFrameLossless) const;
 
   /** compresses the given uncompressed DICOM image and stores
    *  the result in the given pixSeq element.

--- a/dcmdata/include/dcmtk/dcmdata/dcrlecce.h
+++ b/dcmdata/include/dcmtk/dcmdata/dcrlecce.h
@@ -86,6 +86,9 @@ public:
    *  @param decompressedColorModel upon successful return, the color model
    *    of the decompressed image (which may be different from the one used
    *    in the compressed images) is returned in this parameter.
+   *  @param isFrameLossless upon successful return, the lossless attribute
+   *    of the decompressed image (which may be different from the one used
+   *    in the transfer syntax) is returned in this parameter.
    *  @return EC_Normal if successful, an error code otherwise.
    */
   virtual OFCondition decodeFrame(
@@ -97,7 +100,8 @@ public:
     Uint32& startFragment,
     void *buffer,
     Uint32 bufSize,
-    OFString& decompressedColorModel) const;
+    OFString& decompressedColorModel,
+    OFBool& isFrameLossless) const;
 
   /** compresses the given uncompressed DICOM image and stores
    *  the result in the given pixSeq element.

--- a/dcmdata/libsrc/dccodec.cc
+++ b/dcmdata/libsrc/dccodec.cc
@@ -475,7 +475,8 @@ OFCondition DcmCodecList::decodeFrame(
   Uint32& startFragment,
   void *buffer,
   Uint32 bufSize,
-  OFString& decompressedColorModel)
+  OFString& decompressedColorModel,
+  OFBool& isFrameLossless)
 {
 #ifdef WITH_THREADS
   if (! codecLock.initialized()) return EC_IllegalCall; // should never happen
@@ -496,7 +497,7 @@ OFCondition DcmCodecList::decodeFrame(
       if ((*first)->codec->canChangeCoding(fromXfer, EXS_LittleEndianExplicit))
       {
         result = (*first)->codec->decodeFrame(fromParam, fromPixSeq, (*first)->codecParameter,
-                 dataset, frameNo, startFragment, buffer, bufSize, decompressedColorModel);
+                 dataset, frameNo, startFragment, buffer, bufSize, decompressedColorModel, isFrameLossless);
         first = last;
       } else ++first;
     }

--- a/dcmdata/libsrc/dcpixel.cc
+++ b/dcmdata/libsrc/dcpixel.cc
@@ -1214,11 +1214,12 @@ OFCondition DcmPixelData::getUncompressedFrame(
     }
     else
     {
+      OFBool isFrameLossless;
       // we only have a compressed version of the pixel data.
       // Identify a codec for decompressing the frame.
       result = DcmCodecList::decodeFrame(
         (*original)->repType, (*original)->repParam, (*original)->pixSeq,
-        dataset, frameNo, startFragment, buffer, bufSize, decompressedColorModel);
+        dataset, frameNo, startFragment, buffer, bufSize, decompressedColorModel, isFrameLossless);
     }
     return result;
 }

--- a/dcmdata/libsrc/dcrleccd.cc
+++ b/dcmdata/libsrc/dcrleccd.cc
@@ -447,9 +447,11 @@ OFCondition DcmRLECodecDecoder::decodeFrame(
     Uint32& startFragment,
     void *buffer,
     Uint32 bufSize,
-    OFString& decompressedColorModel) const
+    OFString& decompressedColorModel,
+    OFBool& isFrameLossless) const
 {
     OFCondition result = EC_Normal;
+    isFrameLossless = true;
 
     // assume we can cast the codec parameter to what we need
     const DcmRLECodecParameter *djcp = OFstatic_cast(const DcmRLECodecParameter *, cp);

--- a/dcmdata/libsrc/dcrlecce.cc
+++ b/dcmdata/libsrc/dcrlecce.cc
@@ -84,7 +84,8 @@ OFCondition DcmRLECodecEncoder::decodeFrame(
     Uint32& /* startFragment */ ,
     void * /* buffer */ ,
     Uint32 /* bufSize */ ,
-    OFString& /* decompressedColorModel */ ) const
+    OFString& /* decompressedColorModel */ ,
+    OFBool& /* isFrameLossless */ ) const
 {
   // we are an encoder only
   return EC_IllegalCall;

--- a/dcmjpeg/include/dcmtk/dcmjpeg/djcodecd.h
+++ b/dcmjpeg/include/dcmtk/dcmjpeg/djcodecd.h
@@ -98,6 +98,9 @@ public:
    *  @param decompressedColorModel upon successful return, the color model
    *    of the decompressed image (which may be different from the one used
    *    in the compressed images) is returned in this parameter.
+   *  @param isFrameLossless upon successful return, the lossless attribute
+   *    of the decompressed image (which may be different from the one used
+   *    in the transfer syntax) is returned in this parameter.
    *  @return EC_Normal if successful, an error code otherwise.
    */
   virtual OFCondition decodeFrame(
@@ -109,7 +112,8 @@ public:
     Uint32& startFragment,
     void *buffer,
     Uint32 bufSize,
-    OFString& decompressedColorModel) const;
+    OFString& decompressedColorModel,
+    OFBool& isFrameLossless) const;
 
   /** compresses the given uncompressed DICOM image and stores
    *  the result in the given pixSeq element.

--- a/dcmjpeg/include/dcmtk/dcmjpeg/djcodece.h
+++ b/dcmjpeg/include/dcmtk/dcmjpeg/djcodece.h
@@ -102,6 +102,9 @@ public:
    *  @param decompressedColorModel upon successful return, the color model
    *    of the decompressed image (which may be different from the one used
    *    in the compressed images) is returned in this parameter.
+   *  @param isFrameLossless upon successful return, the lossless attribute
+   *    of the decompressed image (which may be different from the one used
+   *    in the transfer syntax) is returned in this parameter.
    *  @return EC_Normal if successful, an error code otherwise.
    */
   virtual OFCondition decodeFrame(
@@ -113,7 +116,8 @@ public:
     Uint32& startFragment,
     void *buffer,
     Uint32 bufSize,
-    OFString& decompressedColorModel) const;
+    OFString& decompressedColorModel,
+    OFBool& isFrameLossless) const;
 
   /** compresses the given uncompressed DICOM image and stores
    *  the result in the given pixSeq element.

--- a/dcmjpeg/libsrc/djcodecd.cc
+++ b/dcmjpeg/libsrc/djcodecd.cc
@@ -408,7 +408,8 @@ OFCondition DJCodecDecoder::decodeFrame(
     Uint32& startFragment,
     void *buffer,
     Uint32 bufSize,
-    OFString& decompressedColorModel) const
+    OFString& decompressedColorModel,
+    OFBool& isFrameLossless) const
 {
 
   OFCondition result = EC_Normal;
@@ -645,9 +646,10 @@ OFCondition DJCodecDecoder::determineDecompressedColorModel(
       if (buffer != NULL)
       {
         DCMJPEG_DEBUG("decompressing first frame to determine the decompressed color model");
+        OFBool isFrameLossless;
         // simple approach: decode first frame in order to determine the uncompressed color model
         result = decodeFrame(fromParam, fromPixSeq, cp, dataset, 0 /* frameNo */, startFragment,
-          OFstatic_cast(void *, buffer), bufSize, decompressedColorModel);
+          OFstatic_cast(void *, buffer), bufSize, decompressedColorModel, isFrameLossless);
       } else
         result = EC_MemoryExhausted;
       delete[] buffer;

--- a/dcmjpeg/libsrc/djcodece.cc
+++ b/dcmjpeg/libsrc/djcodece.cc
@@ -96,7 +96,8 @@ OFCondition DJCodecEncoder::decodeFrame(
   Uint32& /* startFragment */ ,
   void * /* buffer */ ,
   Uint32 /* bufSize */ ,
-  OFString& /* decompressedColorModel */ ) const
+  OFString& /* decompressedColorModel */ ,
+  OFBool& /* isFrameLossless */ ) const
 {
   // we are an encoder only
   return EC_IllegalCall;

--- a/dcmjpls/include/dcmtk/dcmjpls/djcodecd.h
+++ b/dcmjpls/include/dcmtk/dcmjpls/djcodecd.h
@@ -91,6 +91,9 @@ public:
    *  @param decompressedColorModel upon successful return, the color model
    *    of the decompressed image (which may be different from the one used
    *    in the compressed images) is returned in this parameter.
+   *  @param isFrameLossless upon successful return, the lossless attribute
+   *    of the decompressed image (which may be different from the one used
+   *    in the transfer syntax) is returned in this parameter.
    *  @return EC_Normal if successful, an error code otherwise.
    */
   virtual OFCondition decodeFrame(
@@ -102,7 +105,8 @@ public:
     Uint32& startFragment,
     void *buffer,
     Uint32 bufSize,
-    OFString& decompressedColorModel) const;
+    OFString& decompressedColorModel,
+    OFBool& isFrameLossless) const;
 
   /** compresses the given uncompressed DICOM image and stores
    *  the result in the given pixSeq element.
@@ -237,7 +241,8 @@ private:
     Uint16 imageColumns,
     Uint16 imageRows,
     Uint16 imageSamplesPerPixel,
-    Uint16 bytesPerSample);
+    Uint16 bytesPerSample,
+    OFBool& isFrameLossless);
 
   /** determines if a given image requires color-by-plane planar configuration
    *  depending on SOP Class UID (DICOM IOD) and photometric interpretation.

--- a/dcmjpls/include/dcmtk/dcmjpls/djcodece.h
+++ b/dcmjpls/include/dcmtk/dcmjpls/djcodece.h
@@ -94,6 +94,9 @@ public:
    *  @param decompressedColorModel upon successful return, the color model
    *    of the decompressed image (which may be different from the one used
    *    in the compressed images) is returned in this parameter.
+   *  @param isFrameLossless upon successful return, the lossless attribute
+   *    of the decompressed image (which may be different from the one used
+   *    in the transfer syntax) is returned in this parameter.
    *  @return EC_Normal if successful, an error code otherwise.
    */
   virtual OFCondition decodeFrame(
@@ -105,7 +108,8 @@ public:
     Uint32& startFragment,
     void *buffer,
     Uint32 bufSize,
-    OFString& decompressedColorModel) const;
+    OFString& decompressedColorModel,
+    OFBool& isFrameLossless) const;
 
   /** compresses the given uncompressed DICOM image and stores
    *  the result in the given pixSeq element.

--- a/dcmjpls/libsrc/djcodece.cc
+++ b/dcmjpls/libsrc/djcodece.cc
@@ -122,7 +122,8 @@ OFCondition DJLSEncoderBase::decodeFrame(
     Uint32& /* startFragment */ ,
     void * /* buffer */ ,
     Uint32 /* bufSize */ ,
-    OFString& /* decompressedColorModel */ ) const
+    OFString& /* decompressedColorModel */ ,
+    OFBool& /* isFrameLossless */ ) const
 {
   // we are an encoder only
   return EC_IllegalCall;


### PR DESCRIPTION
While browsing the DCMTK code base, I stumble upon the following lines:

http://git.dcmtk.org/?p=dcmtk.git;a=blob;f=dcmjpls/libsrc/djcodecd.cc;h=fc0df5c7f2bf60730e80638aef3491fcbc292804;hb=HEAD#l217

217     // set Lossy Image Compression to "01" (see DICOM part 3, C.7.6.1.1.5)
218     if (result.good() && (supportedTransferSyntax() ==
EXS_JPEGLSLossy)) result =
ditem->putAndInsertString(DCM_LossyImageCompression, "01");

This implementation is too strict per interpretation of PS 3.5 Section
A.4.3 JPEG-LS Image Compression.

The note #2 explicitly states that Transfer Syntax for Near Lossless
may be used:

[...]
Note that this process can, at the discretion of the encoder, be used
to compress images with an error constrained to a value of zero,
resulting in no loss of information.
[...]

In this case, a file decompressed by DCMTK even if originally lossless
(but using the transfer syntax "1.2.840.10008.1.2.4.81 "), will appear
to the rest of the world as lossy compressed:

Implication is that:

[...]
 It provides a means to record that the Image has been compressed (at
a point in its lifetime) with a lossy algorithm and changes have been
introduced into the pixel data. Once the value has been set to "01",
it shall not be reset.
[...]

I would suggest changing the signature of decodeFrame to also return
the max deviation as found in the JPEG-LS stream. Based on this value
(ie. != 0), then one can with confidence set the Attribute Lossy Image
Compression (0028,2110)