### PR TITLE
Reduce a warning level message to a single info level

### DIFF
--- a/CMake/GenerateDCMTKConfigure.cmake
+++ b/CMake/GenerateDCMTKConfigure.cmake
@@ -18,13 +18,20 @@ else()
   set(DCM_DICT_DEFAULT 0)
 endif()
 
+# Evaluation of old DCMDICTPATH environment variable
+if(DEFINED DCMTK_ENABLE_BUILTIN_DICTIONARY)
+  message(WARNING "Usage of DCMTK_ENABLE_BUILTIN_DICTIONARY has been deprecated, see DCMTK_DEFAULT_DICT")
+endif()
+if(DEFINED DCMTK_ENABLE_EXTERNAL_DICTIONARY)
+  message(WARNING "Usage of DCMTK_ENABLE_EXTERNAL_DICTIONARY has been deprecated, see DCMTK_USE_DCMDICTPATH")
+endif()
 # Evaluation of DCMDICTPATH environment variable
 if(DCMTK_USE_DCMDICTPATH)
   set(DCM_DICT_USE_DCMDICTPATH 1)
   message(STATUS "Info: DCMTK will load dictionaries defined by DCMDICTPATH environment variable")
 else()
   set(DCM_DICT_USE_DCMDICTPATH "")
-  message(WARNING "Info: DCMTK will not load dictionaries defined by DCMDICTPATH environment variable")
+  message(STATUS "Warn: DCMTK will not load dictionaries defined by DCMDICTPATH environment variable")
 endif()
 
 # Private tags


### PR DESCRIPTION
Since commit 4ab084d3f the new way to disable external dictionary is to
use DCMTK_USE_DCMDICTPATH=OFF. However setting this configuration
triggers a warning message which may confuse the user. Instead reduce
the level to simply an info level. This variable is for advanced user
anyway. This makes the behavior consistant with the previous one.

Add new warning level messages for user transitioning from the previous
settings to the new settings.