### PR TITLE
Simplify code and remove explicit cast not required.

### DIFF
--- a/dcmimgle/include/dcmtk/dcmimgle/diovpln.h
+++ b/dcmimgle/include/dcmtk/dcmimgle/diovpln.h
@@ -553,11 +553,11 @@ inline int DiOverlayPlane::getNextBit()
 {
     int result;
     if (BitsAllocated == 16)                                        // optimization
-        result = OFstatic_cast(int, *(Ptr++) & (1 << BitPosition));
+        result = *(Ptr++) & (1 << BitPosition);
     else
     {
         Ptr = StartPtr + (BitPos >> 4);                             // div 16
-        result = OFstatic_cast(int, *Ptr & (1 << (BitPos & 0xf)));  // mod 16
+        result = *Ptr & (1 << (BitPos & 0xf));                      // mod 16
         BitPos += BitsAllocated;                                    // next bit
     }
     return result;


### PR DESCRIPTION
This removes gcc warning:

 error: useless cast to type ‘int’ [-Werror=useless-cast]