### PR TITLE
Fix a compilation error in DSRListOfItems

### DIFF
--- a/dcmsr/include/dcmtk/dcmsr/dsrtlist.h
+++ b/dcmsr/include/dcmtk/dcmsr/dsrtlist.h
@@ -299,7 +299,7 @@ template<class T> class DSRListOfItems
     OFCondition removeItem(const size_t idx)
     {
         OFCondition result = EC_IllegalParameter;
-        OFLIST_TYPENAME OFListIterator(T) iterator = ItemList.begin();
+        OFLIST_TYPENAME OFListConstIterator(T) iterator = ItemList.begin();
         if (gotoItemPos(idx, iterator))
         {
             ItemList.erase(iterator);


### PR DESCRIPTION
This is triggered when using DCMTK_ENABLE_STL:BOOL=ON and a c++14
compiler.

  % cat t.cxx
  #include <dcmtk/dcmsr/dsrtlist.h>
  int main()
  {
    DSRListOfItems<int> l;
    l.removeItem(0);
  }

Gives:

  dsrtlist.h:303:30: error: cannot convert 'std::__cxx11::list<int, std::allocator<int> >::iterator' to 'std::__cxx11::list<int, std::allocator<int> >::const_iterator&'