### PR TITLE
Added check on no Unique Keys found in "strict mode".

### DIFF
--- a/dcmqrdb/libsrc/dcmqrdbi.cc
+++ b/dcmqrdb/libsrc/dcmqrdbi.cc
@@ -1130,6 +1130,10 @@ OFCondition DcmQueryRetrieveIndexDatabaseHandle::testFindRequestList (
                 else
                     uniqueKeyFound = OFTrue ;
             }
+            if (! uniqueKeyFound) {
+                DCMQRDB_DEBUG("No Unique Key found (level " << level << ")");
+                return QR_EC_IndexDatabaseError ;
+            }
         }
 
         /**** If current level is the QueryLevel


### PR DESCRIPTION
**Description**

When starting the dcmqrscp server using the -XF option and performing C-FIND query that has no keys in the levels above the Query/Retrieve Level, the returned error code is :

`0xc000: Failed: Unable to process`

This error code is caught after the function that strictly checks the query's conformity.

It can be tested by the following :

`findscu localhost 22222 -P -k QueryRetrieveLevel=STUDY -k StudyDate=20220314`

**Expected behavior**

The error code that should be returned according to the current implementation is the following :

`0xa900: Error: Data Set does not match SOP Class`