### PR TITLE
Permit customization of secure transport layer in DcmTLSSCU

### DIFF
--- a/dcmtls/include/dcmtk/dcmtls/tlsscu.h
+++ b/dcmtls/include/dcmtk/dcmtls/tlsscu.h
@@ -192,6 +192,16 @@ public:
    */
   virtual OFString getWriteSeedFile() const;
 
+protected:
+  /** Factory function for new TLS transport layer instances.
+   *  This function is used by initNetwork to create the transport layer.
+   *  Override this function to allow custom configuration of TLS, and allow
+   *  configuring the transport layer with certificates from third party
+   *  certificate stores. 
+   *  @return a new TLS transport layer instance or NULL in case of failure
+   */
+  virtual DcmTLSTransportLayer* CreateTransportLayer();
+
 private:
 
   /** Private undefined copy-constructor. Shall never be called.

--- a/dcmtls/libsrc/tlsscu.cc
+++ b/dcmtls/libsrc/tlsscu.cc
@@ -86,7 +86,7 @@ OFCondition DcmTLSSCU::initNetwork()
   OFCondition cond;
 
   /* First, create TLS layer */
-  m_tLayer = new DcmTLSTransportLayer(NET_REQUESTOR, m_readSeedFile.c_str(), OFTrue /* initialize OpenSSL */);
+  m_tLayer = CreateTransportLayer();
   if (m_tLayer == NULL)
   {
     DCMTLS_ERROR("Unable to create TLS transport layer for SCP, maybe problem with seed file?");
@@ -340,6 +340,11 @@ void DcmTLSSCU::setDHParam(const OFString& dhParam)
 {
   if (!m_tLayer->setTempDHParameters(dhParam.c_str()))
      DCMTLS_WARN("unable to load temporary DH parameter file '" << dhParam << "', ignoring");
+}
+
+DcmTLSTransportLayer* DcmTLSSCU::CreateTransportLayer()
+{
+    return new DcmTLSTransportLayer(NET_REQUESTOR, m_readSeedFile.c_str(), OFTrue /* initialize OpenSSL */);
 }
 
 #else

--- a/dcmtls/tests/tests.cc
+++ b/dcmtls/tests/tests.cc
@@ -24,5 +24,6 @@
 
 OFTEST_REGISTER(dcmtls_scp_tls);
 OFTEST_REGISTER(dcmtls_scp_pool_tls);
+OFTEST_REGISTER(dcmtls_initNetworkFails_WhenCreateTransportLayerReturnsNull);
 
 OFTEST_MAIN("dcmtls")

--- a/dcmtls/tests/tscuscptls.cc
+++ b/dcmtls/tests/tscuscptls.cc
@@ -483,6 +483,21 @@ OFTEST_FLAGS(dcmtls_scp_pool_tls, EF_None)
     pool.join();
 }
 
+struct CustomTLSSCU : DcmTLSSCU
+{
+    virtual DcmTLSTransportLayer* CreateTransportLayer()
+    {
+        return nullptr;
+    }
+};
+
+OFTEST(dcmtls_initNetworkFails_WhenCreateTransportLayerReturnsNull)
+{
+    CustomTLSSCU scu;
+    scu.enableAuthentication("", "");
+    OFCHECK(scu.initNetwork().bad());
+}
+
 #endif // WITH_OPENSSL
 
 #endif // WITH_THREADS


### PR DESCRIPTION
Today, DcmTLSSCU requires certificate and key files to enable TLS.
The Windows platform has its own certificate store, and exporting all
certificates to the filesystem may not be desireable. Instead, we want
to populate the OpenSSL certificate store in memory from the Windows
certificate store.

This change allow us to derive from DcmTLSSCU to customize how TLS
transport layers are created and configured before we leave it over
to the default DcmTLSSCU::initNetwork implementation.