### PR TITLE
Fix issue with port conflicts when running automated DICOM networking tests in a CI infrastructure

### DIFF
--- a/dcmnet/libsrc/dul.cc
+++ b/dcmnet/libsrc/dul.cc
@@ -2240,6 +2240,14 @@ initializeNetworkTCP(PRIVATE_NETWORKKEY ** key, void *parameter)
         msg += OFStandard::getLastNetworkErrorCode().message();
         return makeDcmnetCondition(DULC_TCPINITERROR, OF_error, msg.c_str());
       }
+
+      /* If port 0 was specified by the client, the OS has assigned an unused port. */
+      if ((*key)->networkSpecific.TCP.port == 0) {
+        const u_short assignedPort = ntohs(server.sin_port);
+        (*key)->networkSpecific.TCP.port = assignedPort;
+        *(int *) parameter = assignedPort;
+      }
+
       sockarg.l_onoff = 0;
       if (setsockopt(sock, SOL_SOCKET, SO_LINGER, (char *) &sockarg, sizeof(sockarg)) < 0)
       {

--- a/dcmnet/libsrc/scp.cc
+++ b/dcmnet/libsrc/scp.cc
@@ -113,11 +113,18 @@ OFCondition DcmSCP::openListenPort()
         return result;
 
     // Initialize network, i.e. create an instance of T_ASC_Network*.
-    cond = ASC_initializeNetwork(NET_ACCEPTOR, OFstatic_cast(int, m_cfg->getPort()), m_cfg->getACSETimeout(), &m_network);
+    const int port = OFstatic_cast(int, m_cfg->getPort());
+    cond = ASC_initializeNetwork(NET_ACCEPTOR, port, m_cfg->getACSETimeout(), &m_network);
     if (cond.bad())
     {
         m_network = NULL;
         return cond;
+    }
+
+    // Update config with assigned port if client requested it
+    if (port == 0)
+    {
+      m_cfg->setPort(OFstatic_cast(Uint16, m_network->acceptorPort));
     }
 
     if (m_cfg->transportLayerEnabled())

--- a/dcmnet/tests/tscuscp.cc
+++ b/dcmnet/tests/tscuscp.cc
@@ -216,7 +216,7 @@ void scu_sends_echo(
     OFCondition result;
     OFCHECK_MSG((result = scu.addPresentationContext(UID_VerificationSOPClass, xfers)).good(), result.text());
     OFCHECK_MSG((result = scu.initNetwork()).good(), result.text());
-    OFCHECK_MSG((result = scu.negotiateAssociation()).good(), result.text());
+    OFCHECK_MSG((result = scu.negotiateAssociation()).good() || expect_assoc_reject, result.text());
     if (!expect_assoc_reject)
     {
         OFCHECK_MSG((result = scu.sendECHORequest(1)).good(), result.text());

--- a/dcmnet/tests/tscuscp.cc
+++ b/dcmnet/tests/tscuscp.cc
@@ -167,11 +167,11 @@ struct TestSCP: DcmSCP, OFThread
     /// Indicator whether related virtual notifier function was called
     OFBool m_notify_assoc_termination_result;
 
-    /** Method called by OFThread to start SCP operation. Starts listen() loop of DcmSCP.
+    /** Method called by OFThread to start SCP operation. Starts acceptAssociations() loop of DcmSCP.
     */
     virtual void run()
     {
-        m_listen_result = listen();
+        m_listen_result = acceptAssociations();
     }
 
 };
@@ -199,6 +199,7 @@ void configure_scp_for_echo(DcmSCPConfig& cfg, Uint16 listenPort, T_ASC_SC_ROLE 
  */
 void scu_sends_echo(
   const OFString& called_ae_title,
+  const Uint16 port,
   const OFBool expect_assoc_reject = OFFalse,
   const OFBool do_release = OFTrue,
   const int secs_after_echo = 0,
@@ -210,7 +211,7 @@ void scu_sends_echo(
     scu.setAETitle("TEST_SCU");
     scu.setPeerAETitle(called_ae_title);
     scu.setPeerHostName("localhost");
-    scu.setPeerPort(11112);
+    scu.setPeerPort(port);
     OFList<OFString> xfers;
     xfers.push_back(UID_LittleEndianImplicitTransferSyntax);
     OFCondition result;
@@ -243,13 +244,15 @@ OFTEST_FLAGS(dcmnet_scp_stop_after_current_association, EF_Slow)
     // accordingly
     TestSCP scp;
     DcmSCPConfig& config = scp.getConfig();
-    configure_scp_for_echo(config, 11112);
+    configure_scp_for_echo(config, 0);
     config.setAETitle("STOP_AFTER_ASSOC");
     config.setConnectionBlockingMode(DUL_BLOCK);
+    OFCHECK(scp.openListenPort().good());
+    const Uint16 port = config.getPort();
     scp.start();
 
     // Send ECHO, and wait to be sure SCP has time to exit
-    scu_sends_echo("STOP_AFTER_ASSOC");
+    scu_sends_echo("STOP_AFTER_ASSOC", port);
     // Make sure server would have time to return
     OFStandard::forceSleep(2);
 
@@ -263,7 +266,7 @@ OFTEST_FLAGS(dcmnet_scp_stop_after_current_association, EF_Slow)
     // Tell SCP to stop after association and run SCU again
     scp.clear();
     scp.m_set_stop_after_assoc = OFTrue;
-    scu_sends_echo("STOP_AFTER_ASSOC");
+    scu_sends_echo("STOP_AFTER_ASSOC", port);
     OFStandard::forceSleep(2);
 
     // Check whether all test variables have the correct values
@@ -290,16 +293,8 @@ OFTEST_FLAGS(dcmnet_scp_fail_on_invalid_association_configuration, EF_Slow)
     // related thread returns anyway.
     config.setConnectionTimeout(3);
     scp.m_set_stop_after_timeout = OFTrue;
-    // Start server and check that it returns with the expected return value.
-    // In this case we did not configure any presentation contexts, so we
-    // expect the related error code.
-    scp.start();
-    scp.join();
-    OFCHECK(scp.m_listen_result == NET_EC_InvalidSCPAssociationProfile);
-    OFCHECK(scp.m_stop_after_assoc_result == OFFalse);
-    OFCHECK(scp.m_stop_after_timeout_result == OFFalse);
-    OFCHECK(scp.m_notify_connection_timeout_result == OFFalse);
-    OFCHECK(scp.m_notify_assoc_termination_result == OFFalse);
+
+    OFCHECK(scp.openListenPort() == NET_EC_InvalidSCPAssociationProfile);
 }
 
 
@@ -311,16 +306,18 @@ OFTEST_FLAGS(dcmnet_scp_fail_on_disallowed_host, EF_Slow)
     // Configure SCP for Verification
     TestSCP scp;
     DcmSCPConfig& config = scp.getConfig();
-    configure_scp_for_echo(config, 11112);
+    configure_scp_for_echo(config, 0);
     config.setAETitle("REJECT_HOST");
     config.setConnectionBlockingMode(DUL_BLOCK);
     // Make sure SCP always returns
     scp.m_set_stop_after_assoc = OFTrue;
     // Tell SCP to reject calling host
     scp.m_set_reject_calling_host = OFTrue;
+    OFCHECK(scp.openListenPort().good());
+    const Uint16 port = config.getPort();
     scp.start();
 
-    scu_sends_echo("REJECT_HOST", OFTrue /* expect that association is being refused */);
+    scu_sends_echo("REJECT_HOST", port, OFTrue /* expect that association is being refused */);
     OFStandard::forceSleep(2);  // make sure server would have time to return
 
     // Check whether all test variables have the correct values
@@ -342,16 +339,18 @@ OFTEST_FLAGS(dcmnet_scp_builtin_verification_support, EF_Slow)
     // Configure SCP and enable built-in Verification SOP Class Handler
     TestSCP scp;
     scp.setEnableVerification();
-    scp.getConfig().setPort(11112);
+    scp.getConfig().setPort(0);
     DcmSCPConfig& config = scp.getConfig();
     config.setAETitle("TEST_BUILTIN_VER");
     config.setConnectionBlockingMode(DUL_BLOCK);
     // Make sure server stops after the SCU connection
     scp.m_set_stop_after_assoc = OFTrue;
+    OFCHECK(scp.openListenPort().good());
+    const Uint16 port = config.getPort();
     scp.start();
 
     // Send echo and receive response
-    scu_sends_echo("TEST_BUILTIN_VER");
+    scu_sends_echo("TEST_BUILTIN_VER", port);
     // make sure server would have time to return
     OFStandard::forceSleep(1);
 
@@ -372,14 +371,16 @@ OFTEST_FLAGS(dcmnet_scp_stop_after_timeout, EF_Slow)
     // is performed, i.e. timeout occurs after that connection.
     TestSCP scp;
     DcmSCPConfig& config = scp.getConfig();
-    configure_scp_for_echo(config, 11112);
+    configure_scp_for_echo(config, 0);
     config.setAETitle("STOP_ON_TIMEOUT");
     config.setConnectionBlockingMode(DUL_NOBLOCK);
     config.setConnectionTimeout(5);
     scp.m_set_stop_after_timeout = OFTrue;
+    OFCHECK(scp.openListenPort().good());
+    const Uint16 port = config.getPort();
     scp.start();
     OFStandard::forceSleep(1);
-    scu_sends_echo("STOP_ON_TIMEOUT");
+    scu_sends_echo("STOP_ON_TIMEOUT", port);
     // Wait for server to return after connection has been served and timeout
     // has been reached
     scp.join();
@@ -401,12 +402,14 @@ OFTEST_FLAGS(dcmnet_scp_no_stop_wo_request_noblock, EF_Slow)
     // SCP to stop after timeout occurs, and start SCP
     TestSCP scp;
     DcmSCPConfig& config = scp.getConfig();
-    configure_scp_for_echo(config, 11112);
+    configure_scp_for_echo(config, 0);
 
     config.setAETitle("NO_STOP_NOBLOCK");
     config.setConnectionBlockingMode(DUL_NOBLOCK);
     config.setConnectionTimeout(1);
     scp.m_set_stop_after_timeout = OFFalse;
+
+    OFCHECK(scp.openListenPort().good());
     scp.start();
 
     // Check whether all test variables have the correct values, especially that
@@ -431,11 +434,13 @@ OFTEST_FLAGS(dcmnet_scp_no_stop_wo_request_block, EF_Slow)
     // Configure SCP for Verification and to do not ask to exit for any reason
     TestSCP scp;
     DcmSCPConfig& config = scp.getConfig();
-    configure_scp_for_echo(config, 11112);
+    configure_scp_for_echo(config, 0);
     config.setAETitle("NO_STOP_BLOCK");
     config.setConnectionBlockingMode(DUL_BLOCK);
+    OFCHECK(scp.openListenPort().good());
+    const Uint16 port = config.getPort();
     scp.start();
-    scu_sends_echo("NO_STOP_BLOCK");
+    scu_sends_echo("NO_STOP_BLOCK", port);
 
     // Give some time to SCP so it could return
     OFStandard::forceSleep(3);
@@ -450,7 +455,7 @@ OFTEST_FLAGS(dcmnet_scp_no_stop_wo_request_block, EF_Slow)
 
     // Stop (already tested in former test cases), therefore, send another ECHO
     scp.m_set_stop_after_assoc = OFTrue;
-    scu_sends_echo("NO_STOP_BLOCK");
+    scu_sends_echo("NO_STOP_BLOCK", port);
     scp.join();
 }
 
@@ -462,11 +467,12 @@ OFTEST_FLAGS(dcmnet_scp_no_term_notify_without_association, EF_Slow)
     // Configure SCP for Verification and tell it stop after 3 seconds.
     TestSCP scp;
     DcmSCPConfig& config = scp.getConfig();
-    configure_scp_for_echo(config, 11112);
+    configure_scp_for_echo(config, 0);
     config.setAETitle("NO_TERM_WO_ASSOC");
     config.setConnectionBlockingMode(DUL_NOBLOCK);
     config.setConnectionTimeout(3);
     scp.m_set_stop_after_timeout = OFTrue;
+    OFCHECK(scp.openListenPort().good());
     scp.start();
     scp.join();
     // Check whether all test variables have the correct values.
@@ -507,11 +513,12 @@ void test_role_selection(const T_ASC_SC_ROLE r_req,
     // Configure SCP for Verification with the desired role, and start it
     TestSCP scp;
     DcmSCPConfig& config = scp.getConfig();
-    configure_scp_for_echo(config, 11112, r_acc);
+    configure_scp_for_echo(config, 0, r_acc);
     config.setAETitle("ACCEPTOR");
     config.setConnectionBlockingMode(DUL_NOBLOCK);
     config.setConnectionTimeout(4);
     config.setAlwaysAcceptDefaultRole(acceptDefaultInsteadOfSCP);
+    OFCHECK(scp.openListenPort().good());
     scp.start();
 
     // Ensure server is up and listening
@@ -522,7 +529,7 @@ void test_role_selection(const T_ASC_SC_ROLE r_req,
     scu.setPeerAETitle("ACCEPTOR");
     scu.setAETitle("REQUESTOR");
     scu.setPeerHostName("localhost");
-    scu.setPeerPort(11112);
+    scu.setPeerPort(config.getPort());
     OFList<OFString> ts;
     ts.push_back(UID_LittleEndianImplicitTransferSyntax);
     OFCHECK(scu.addPresentationContext(UID_VerificationSOPClass, ts, r_req).good());
@@ -633,9 +640,9 @@ struct TestSCPWithNCreateSupport : TestSCP
         config.setConnectionBlockingMode(DUL_NOBLOCK);
         config.setConnectionTimeout(10);
         config.setHostLookupEnabled(OFFalse);
-        OFRandom rnd;
-        m_portNum = 65535 - rnd.getRND16() % 5535; // 60000-65535
-        configure_scp_for_echo(config, m_portNum);
+        configure_scp_for_echo(config, 0);
+        OFCHECK(openListenPort().good());
+        m_portNum = config.getPort();
         OFList<OFString> xfers;
         xfers.push_back(UID_LittleEndianImplicitTransferSyntax);
         OFCHECK(getConfig().addPresentationContext(UID_ModalityPerformedProcedureStepSOPClass, xfers).good());
@@ -879,6 +886,5 @@ OFTEST(dcmnet_scu_sendNCREATERequest_succeeds_and_sets_responsestatuscode_from_s
     fixture.scp.m_set_stop_after_assoc = OFTrue;
     OFCHECK_MSG((result = fixture.mppsSCU.releaseAssociation()).good(), result.text());
 }
-
 
 #endif // WITH_THREADS


### PR DESCRIPTION
When running DICOM networking tests in a CI infrastructure, port conflicts can be a serious obstacle because only one test can run at a time. This prevents efficient utilization of CI hardware.

This change attempts to make DcmSCP more CI friendly by enabling automatic port assignment. This functionality is enabled by configuring the DcmSCP to listen to port 0. The underlying socket library will then assign an unused port to the DcmSCP when opening a listen port. The main part of this change is about propagating this automatically assigned port up to the API level.

This should prevent port conflicts when running multiple tests in parallel on the same OS instance.

