### PR TITLE
Draft: Add possibility to change Implementation Class UID and Implementation Version Name

### DIFF
--- a/dcmdata/include/dcmtk/dcmdata/dcfilefo.h
+++ b/dcmdata/include/dcmtk/dcmdata/dcfilefo.h
@@ -27,6 +27,7 @@
 
 #include "dcmtk/dcmdata/dcsequen.h"
 #include "dcmtk/dcmdata/dcdatset.h"
+#include "dcmtk/dcmdata/dcuid.h"
 
 
 // forward declarations
@@ -390,6 +391,22 @@ class DCMTK_DCMDATA_EXPORT DcmFileFormat
         FileReadMode = readMode;
     }
 
+    /** Method sets Implementation Class UID meta header tag
+     *  @param implementationClassUID tag value
+     */
+    void setImplementationClassUID(const OFString& implementationClassUID)
+    {
+        m_implementationClassUID = implementationClassUID;
+    };
+
+    /** Method sets Implementation Version Name meta header tag
+     *  @param implementationVersionName tag value
+     */
+    void setImplementationVersionName(const OFString& implementationVersionName)
+    {
+        m_implementationVersionName = implementationVersionName;
+    }
+
     /** method inherited from base class that shall not be used for instances of this class.
      *  Method immediately returns with error code.
      *  @param item item
@@ -479,6 +496,8 @@ class DCMTK_DCMDATA_EXPORT DcmFileFormat
      *                   Equals NULL if this data element is not existent in the meta header information.
      *  @param oxfer     The transfer syntax which shall be used.
      *  @param writeMode flag indicating whether to update the file meta information or not
+     *  @param implClassUID meta header tag for Implementation Class UID
+     *  @param implVersionName meta header tag for Implementation Version Name
      *  @return EC_Normal if successful, an error code otherwise
      */
     static OFCondition checkMetaHeaderValue(DcmMetaInfo *metainfo,
@@ -486,7 +505,9 @@ class DCMTK_DCMDATA_EXPORT DcmFileFormat
                                             const DcmTagKey &atagkey,
                                             DcmObject *obj,
                                             const E_TransferSyntax oxfer,
-                                            const E_FileWriteMode writeMode);
+                                            const E_FileWriteMode writeMode,
+                                            const OFString& implClassUID = OFFIS_IMPLEMENTATION_CLASS_UID,
+                                            const OFString& implVersionName = OFFIS_DTK_IMPLEMENTATION_VERSION_NAME);
 
     /** read DCM_TransferSyntaxUID from meta header dataset and return as E_TransferSyntax value
      *  @param metainfo meta-header dataset
@@ -496,6 +517,10 @@ class DCMTK_DCMDATA_EXPORT DcmFileFormat
 
     /// file read mode, specifies whether to read the meta header or not
     E_FileReadMode FileReadMode;
+
+    /// Meta header tags:
+    OFString m_implementationClassUID;
+    OFString m_implementationVersionName;
 };
 
 

--- a/dcmnet/include/dcmtk/dcmnet/assoc.h
+++ b/dcmnet/include/dcmtk/dcmnet/assoc.h
@@ -700,7 +700,8 @@ ASC_receiveAssociation(
     unsigned long *associatePDUlength=NULL,
     OFBool useSecureLayer=OFFalse,
     DUL_BLOCKOPTIONS block=DUL_BLOCK,
-    int timeout=0);
+    int timeout=0, 
+    const T_ASC_ImplementationIdentification& implIdentification = T_ASC_ImplementationIdentification());
 
 DCMTK_DCMNET_EXPORT OFCondition
 ASC_acknowledgeAssociation(

--- a/dcmnet/include/dcmtk/dcmnet/assoc.h
+++ b/dcmnet/include/dcmtk/dcmnet/assoc.h
@@ -217,6 +217,13 @@ struct DCMTK_DCMNET_EXPORT T_ASC_RejectParameters
     T_ASC_RejectParametersReason reason;
 };
 
+struct DCMTK_DCMNET_EXPORT T_ASC_ImplementationIdentification
+{
+    T_ASC_ImplementationIdentification();
+
+    DIC_UI ourImplementationClassUID;
+    DIC_SH ourImplementationVersionName;
+};
 
 struct DCMTK_DCMNET_EXPORT T_ASC_Parameters
 {
@@ -295,7 +302,9 @@ DCMTK_DCMNET_EXPORT OFCondition
 ASC_createAssociationParameters(
     T_ASC_Parameters ** params,
     long maxReceivePDUSize,
-    Sint32 tcpConnectTimeout);
+    Sint32 tcpConnectTimeout,
+    const T_ASC_ImplementationIdentification& implIdentification = T_ASC_ImplementationIdentification()
+    );
 
 /*
  * same as before, but uses value of the global dcmConnectionTimeout variable.

--- a/dcmnet/include/dcmtk/dcmnet/scpcfg.h
+++ b/dcmnet/include/dcmtk/dcmnet/scpcfg.h
@@ -140,6 +140,16 @@ public:
   OFCondition checkAssociationProfile(const OFString &profileName,
                                       OFString& mangledName) const;
 
+  /** Set an association implementation identification parameters
+   *  @param impIndetification [in] Implementation Class UID and Implementation Version Name
+   */
+  void setImplementationIdentification(const T_ASC_ImplementationIdentification& implIndetification);
+
+  /** Returns association implementation identification parameters
+   *  @return Implementation Class UID and Implementation Version Name
+   */
+  const T_ASC_ImplementationIdentification& getImplementationIdentification();
+
   /** Force every association request to be refused by SCP, no matter what the SCU is
    *  offering
    *  @param doRefuse [in] If OFTrue, every association is being refused. DcmSCP's default
@@ -359,6 +369,9 @@ protected:
   /// Profile in association configuration that should be used. By default, a profile
   /// called "DEFAULT" is used.
   OFString m_assocCfgProfileName;
+
+  /// Implementation Class UID and Implementation Version Name
+  T_ASC_ImplementationIdentification m_implIdentification;
 
   /// Port on which the SCP is listening for association requests. The default port is 104.
   Uint16 m_port;

--- a/dcmnet/include/dcmtk/dcmnet/scu.h
+++ b/dcmnet/include/dcmtk/dcmnet/scu.h
@@ -692,6 +692,11 @@ public:
      */
     void setAssocConfigFileAndProfile(const OFString& filename, const OFString& profile);
 
+    /** Set an association implementation identification parameters
+     *  @param implIndetification [in] Implementation Class UID and Implementation Version Name
+     */
+    void setImplementationIdentification(const T_ASC_ImplementationIdentification& implIndetification);
+
     /** Set the directory that should be used by the standard C-GET handler to store objects
      *  that come in with the corresponding C-STORE requests
      *  @param storeDir [in] The directory to store to. It is checked in handleSTORERequest()
@@ -1059,6 +1064,9 @@ private:
 
     /// Configuration file containing association parameters
     OFString m_assocConfigFile;
+
+    /// Implementation Class UID and Implementation Version Name
+    T_ASC_ImplementationIdentification m_implIdentification;
 
     /// The last DIMSE successfully sent, unresponded DIMSE request
     T_DIMSE_Message* m_openDIMSERequest;

--- a/dcmnet/libsrc/assoc.cc
+++ b/dcmnet/libsrc/assoc.cc
@@ -1767,7 +1767,8 @@ ASC_receiveAssociation(T_ASC_Network * network,
                        unsigned long *associatePDUlength,
                        OFBool useSecureLayer,
                        DUL_BLOCKOPTIONS block,
-                       int timeout)
+                       int timeout,
+                       const T_ASC_ImplementationIdentification& implIdentification)
 {
     T_ASC_Parameters *params;
     DUL_ASSOCIATIONKEY *DULassociation;
@@ -1777,7 +1778,7 @@ ASC_receiveAssociation(T_ASC_Network * network,
     int retrieveRawPDU = 0;
     if (associatePDU && associatePDUlength) retrieveRawPDU = 1;
 
-    OFCondition cond = ASC_createAssociationParameters(&params, maxReceivePDUSize, dcmConnectionTimeout.get());
+    OFCondition cond = ASC_createAssociationParameters(&params, maxReceivePDUSize, dcmConnectionTimeout.get(), implIdentification);
     if (cond.bad()) return cond;
 
     cond = ASC_setTransportLayerType(params, useSecureLayer);

--- a/dcmnet/libsrc/assoc.cc
+++ b/dcmnet/libsrc/assoc.cc
@@ -209,6 +209,22 @@ typedef struct {
 } T_ASC_ExtendedNegotiationItem;
 
 
+T_ASC_ImplementationIdentification::T_ASC_ImplementationIdentification()
+{
+    OFStandard::strlcpy(ourImplementationClassUID,
+        OFFIS_IMPLEMENTATION_CLASS_UID,
+        sizeof(ourImplementationClassUID));
+    OFStandard::strlcpy(ourImplementationVersionName,
+        OFFIS_DTK_IMPLEMENTATION_VERSION_NAME,
+        sizeof(ourImplementationVersionName));
+
+    if (strlen(OFFIS_DTK_IMPLEMENTATION_VERSION_NAME) > 16)
+    {
+        DCMNET_WARN("DICOM implementation version name too long: " << OFFIS_DTK_IMPLEMENTATION_VERSION_NAME);
+    }
+}
+
+
 /*
 ** Function Bodies
 */
@@ -274,24 +290,19 @@ ASC_dropNetwork(T_ASC_Network ** network)
 OFCondition
 ASC_createAssociationParameters(T_ASC_Parameters ** params,
                                 long maxReceivePDUSize,
-                                Sint32 tcpConnectTimeout)
+                                Sint32 tcpConnectTimeout,
+                                const T_ASC_ImplementationIdentification& implIdentification)
 {
-
     *params = (T_ASC_Parameters *) malloc(sizeof(**params));
     if (*params == NULL) return EC_MemoryExhausted;
     memset((char*)*params, 0, sizeof(**params));
 
     OFStandard::strlcpy((*params)->ourImplementationClassUID,
-            OFFIS_IMPLEMENTATION_CLASS_UID,
+            implIdentification.ourImplementationClassUID,
             sizeof((*params)->ourImplementationClassUID));
     OFStandard::strlcpy((*params)->ourImplementationVersionName,
-            OFFIS_DTK_IMPLEMENTATION_VERSION_NAME,
+            implIdentification.ourImplementationVersionName,
             sizeof((*params)->ourImplementationVersionName));
-
-    if (strlen(OFFIS_DTK_IMPLEMENTATION_VERSION_NAME) > 16)
-    {
-      DCMNET_WARN("DICOM implementation version name too long: " << OFFIS_DTK_IMPLEMENTATION_VERSION_NAME);
-    }
 
     OFStandard::strlcpy((*params)->DULparams.callingImplementationClassUID,
         (*params)->ourImplementationClassUID, DICOM_UI_LENGTH + 1);

--- a/dcmnet/libsrc/scp.cc
+++ b/dcmnet/libsrc/scp.cc
@@ -393,7 +393,8 @@ OFCondition DcmSCP::waitForAssociationRQ(T_ASC_Network* network)
                                               NULL,
                                               useSecureLayer,
                                               m_cfg->getConnectionBlockingMode(),
-                                              OFstatic_cast(int, timeout));
+                                              OFstatic_cast(int, timeout),
+                                              m_cfg->getImplementationIdentification());
 
     // In case of a timeout in non-blocking mode, call notifier (and return
     // to main event loop later)

--- a/dcmnet/libsrc/scpcfg.cc
+++ b/dcmnet/libsrc/scpcfg.cc
@@ -56,6 +56,7 @@ DcmSCPConfig::~DcmSCPConfig()
 DcmSCPConfig::DcmSCPConfig(const DcmSCPConfig &old) :
   m_assocConfig(old.m_assocConfig),
   m_assocCfgProfileName(old.m_assocCfgProfileName),
+  m_implIdentification(old.m_implIdentification),
   m_port(old.m_port),
   m_aetitle(old.m_aetitle),
   m_refuseAssociation(old.m_refuseAssociation),
@@ -81,6 +82,7 @@ DcmSCPConfig& DcmSCPConfig::operator=(const DcmSCPConfig &obj)
   {
     m_assocConfig = obj.m_assocConfig; // performs deep copy
     m_assocCfgProfileName = obj.m_assocCfgProfileName;
+    m_implIdentification = obj.m_implIdentification;
     m_port = obj.m_port;
     m_aetitle = obj.m_aetitle;
     m_refuseAssociation = obj.m_refuseAssociation;
@@ -396,6 +398,18 @@ OFCondition DcmSCPConfig::checkAssociationProfile(const OFString& profileName,
   }
 
   return result;
+}
+
+
+void DcmSCPConfig::setImplementationIdentification(const T_ASC_ImplementationIdentification& implIndetification)
+{
+    m_implIdentification = implIndetification;
+}
+
+
+const T_ASC_ImplementationIdentification& DcmSCPConfig::getImplementationIdentification()
+{
+    return m_implIdentification;
 }
 
 

--- a/dcmnet/libsrc/scppool.cc
+++ b/dcmnet/libsrc/scppool.cc
@@ -84,8 +84,15 @@ OFCondition DcmBaseSCPPool::listen()
     OFBool useSecureLayer = m_cfg.transportLayerEnabled();
 
     // Listen to a socket for timeout seconds for an association request, accepts TCP connection.
-    cond = ASC_receiveAssociation( network, &assoc, m_cfg.getMaxReceivePDULength(), NULL, NULL, useSecureLayer,
-        m_cfg.getConnectionBlockingMode(), OFstatic_cast(int, m_cfg.getConnectionTimeout()), m_cfg.getImplementationIdentification());
+    cond = ASC_receiveAssociation(network,
+                                  &assoc,
+                                  m_cfg.getMaxReceivePDULength(),
+                                  NULL,
+                                  NULL,
+                                  useSecureLayer,
+                                  m_cfg.getConnectionBlockingMode(),
+                                  OFstatic_cast(int, m_cfg.getConnectionTimeout()),
+                                  m_cfg.getImplementationIdentification());
 
     /* If we have a connection request, try to find/create a worker to handle it */
     if (cond.good())

--- a/dcmnet/libsrc/scppool.cc
+++ b/dcmnet/libsrc/scppool.cc
@@ -85,7 +85,7 @@ OFCondition DcmBaseSCPPool::listen()
 
     // Listen to a socket for timeout seconds for an association request, accepts TCP connection.
     cond = ASC_receiveAssociation( network, &assoc, m_cfg.getMaxReceivePDULength(), NULL, NULL, useSecureLayer,
-        m_cfg.getConnectionBlockingMode(), OFstatic_cast(int, m_cfg.getConnectionTimeout()) );
+        m_cfg.getConnectionBlockingMode(), OFstatic_cast(int, m_cfg.getConnectionTimeout()), m_cfg.getImplementationIdentification());
 
     /* If we have a connection request, try to find/create a worker to handle it */
     if (cond.good())

--- a/dcmnet/libsrc/scu.cc
+++ b/dcmnet/libsrc/scu.cc
@@ -121,7 +121,7 @@ OFCondition DcmSCU::initNetwork()
     }
 
     /* initialize association parameters, i.e. create an instance of T_ASC_Parameters*. */
-    cond = ASC_createAssociationParameters(&m_params, m_maxReceivePDULength, m_tcpConnectTimeout);
+    cond = ASC_createAssociationParameters(&m_params, m_maxReceivePDULength, m_tcpConnectTimeout, m_implIdentification);
     if (cond.bad())
     {
         DCMNET_ERROR(DimseCondition::dump(tempStr, cond));
@@ -2553,6 +2553,11 @@ void DcmSCU::setAssocConfigFileAndProfile(const OFString& filename, const OFStri
 {
     m_assocConfigFilename = filename;
     m_assocConfigProfile  = profile;
+}
+
+void DcmSCU::setImplementationIdentification(const T_ASC_ImplementationIdentification& implIndetification)
+{
+    m_implIdentification = implIndetification;
 }
 
 void DcmSCU::setStorageDir(const OFString& storeDir)


### PR DESCRIPTION
This PR implements suggestion from #68, which is the initial version.

This change make it possible for client's code to configure the values of ImplementationClassUID and ImplementationVersionName. By default OFFIS values will be used.

It is needed to identify and distinguish implementation environments from each others, especially in case when the module is used by several product types.