### PR TITLE
Move code related for network initialization in DcmBaseSCPPool::listen to the separate function and make it virtual.

### DIFF
--- a/dcmnet/include/dcmtk/dcmnet/scppool.h
+++ b/dcmnet/include/dcmtk/dcmnet/scppool.h
@@ -213,6 +213,13 @@ protected:
   void notifyThreadExit(DcmBaseSCPWorker* thread,
                         OFCondition result);
 
+  /** Initialize network, i.e. create an instance of T_ASC_Network and set
+   *  transport layer if it is enabled.
+   *  @param network The T_ASC_Network pointer to create the instance
+   *  @return EC_Normal if there were no errors during initialization.
+   */
+  virtual OFCondition initializeNework(T_ASC_Network** network);
+
 private:
 
   /// Possible run modes of pool

--- a/dcmnet/libsrc/scppool.cc
+++ b/dcmnet/libsrc/scppool.cc
@@ -61,18 +61,9 @@ OFCondition DcmBaseSCPPool::listen()
 
   /* Initialize network, i.e. create an instance of T_ASC_Network*. */
   T_ASC_Network *network = NULL;
-  OFCondition cond = ASC_initializeNetwork( NET_ACCEPTOR, OFstatic_cast(int, m_cfg.getPort()), m_cfg.getACSETimeout(), &network );
-  if( cond.bad() )
+  OFCondition cond = initializeNework(&network);
+  if(cond.bad())
     return cond;
-
-  if (m_cfg.transportLayerEnabled())
-  {
-    cond = ASC_setTransportLayer(network, m_cfg.getTransportLayer(), 0 /* Do not take over ownership */);
-    if (cond.bad())
-    {
-        DCMNET_ERROR("DcmBaseSCPPool: Error setting secured transport layer: " << cond.text());
-    }
-  }
 
   /* As long as all is fine (or we have been to busy handling last connection request) keep listening */
   while ( m_runMode == LISTEN && ( cond.good() || (cond == NET_EC_SCPBusy) ) )
@@ -297,6 +288,26 @@ void DcmBaseSCPPool::notifyThreadExit(DcmBaseSCPPool::DcmBaseSCPWorker* thread,
   m_criticalSection.unlock();
 }
 
+// ----------------------------------------------------------------------------
+
+OFCondition DcmBaseSCPPool::initializeNework(T_ASC_Network** network)
+{
+    OFCondition cond = ASC_initializeNetwork(NET_ACCEPTOR, OFstatic_cast(int, m_cfg.getPort()), m_cfg.getACSETimeout(), network);
+    if (cond.bad())
+        return cond;
+
+    if (m_cfg.transportLayerEnabled())
+    {
+        cond = ASC_setTransportLayer(*network, m_cfg.getTransportLayer(), 0 /* Do not take over ownership */);
+        if (cond.bad())
+        {
+            DCMNET_ERROR("DcmBaseSCPPool: Error setting secured transport layer: " << cond.text());
+            ASC_dropNetwork(network);
+        }
+    }
+
+    return cond;
+}
 
 /* *********************************************************************** */
 /*                        DcmBaseSCPPool::BaseSCPWorker class              */


### PR DESCRIPTION
This way it is possible for the clients to implement a notification about the results of the network initialization part. It is needed to be able to get feedback for the cases where,  for example, the selected port is already taken.