### PR TITLE
Add missing include of Windows.h in dcdict.cc

### DIFF
--- a/dcmdata/libsrc/dcdict.cc
+++ b/dcmdata/libsrc/dcdict.cc
@@ -30,6 +30,11 @@
 #include "dcmtk/ofstd/ofstd.h"
 #include "dcmtk/ofstd/offile.h"
 
+#ifdef HAVE_WINDOWS_H
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+
 /*
 ** The separator character between fields in the data dictionary file(s)
 */


### PR DESCRIPTION
This file uses MAX_PATH without including Windows.h