### PR TITLE
Prevent garbage collection of char buffer

### DIFF
--- a/dcmpstat/libsrc/dvpsga.cc
+++ b/dcmpstat/libsrc/dvpsga.cc
@@ -160,10 +160,10 @@ OFCondition DVPSGraphicAnnotation::addImageReference(
     DVPSObjectApplicability applicability)
 {
   if ((sopclassUID==NULL)||(instanceUID==NULL)||(applicability==DVPSB_allImages)) return EC_IllegalCall;
+  char frameString[100];
   const char *framenumber=NULL;
   if (applicability==DVPSB_currentFrame)
   {
-    char frameString[100];
     sprintf(frameString, "%ld", frame);
     framenumber = frameString;
   }

--- a/dcmpstat/libsrc/dvpsril.cc
+++ b/dcmpstat/libsrc/dvpsril.cc
@@ -217,10 +217,10 @@ OFCondition DVPSReferencedImage_PList::addImageReference(
     DVPSObjectApplicability applicability)
 {
   if ((sopclassUID==NULL)||(instanceUID==NULL)||(applicability==DVPSB_allImages)) return EC_IllegalCall;
+  char frameString[100];
   const char *framenumber=NULL;
   if (applicability==DVPSB_currentFrame)
   {
-    char frameString[100];
     sprintf(frameString, "%ld", frame);
     framenumber = frameString;
   }


### PR DESCRIPTION
Removes compilation warning:

/<<PKGBUILDDIR>>/dcmpstat/libsrc/dvpsril.cc: In member function ‘OFCondition DVPSReferencedImage_PList::addImageReference(const char*, const char*, long unsigned int, DVPSObjectApplicability)’: /<<PKGBUILDDIR>>/dcmpstat/libsrc/dvpsril.cc:227:65: warning: dangling pointer ‘framenumber’ to ‘frameString’ may be used [-Wdangling-pointer=]
  227 |   return addImageReference(sopclassUID, instanceUID, framenumber);
      |                                                                 ^
/<<PKGBUILDDIR>>/dcmpstat/libsrc/dvpsril.cc:223:10: note: ‘frameString’ declared here
  223 |     char frameString[100];
      |          ^~~~~~~~~~~

Fix commit efed5367a7