### PR TITLE
Prevent macro-redefined warning for '__STDC_FORMAT_MACROS'

### DIFF
--- a/ofstd/include/dcmtk/ofstd/oftypes.h
+++ b/ofstd/include/dcmtk/ofstd/oftypes.h
@@ -29,7 +29,9 @@
 
 // some C++ implementations only define printf format macros like PRIu32
 // when this macro is defined before <inttypes.h> or <cinttypes> are included.
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS 1
+#endif
 
 // include this file in doxygen documentation
 


### PR DESCRIPTION
When compiling in tandem with gRPC we experienced the warning: '__STDC_FORMAT_MACROS' macro redefined [-Wmacro-redefined]. On gRPC side the define is checked prior to setting it, this seems to make sense here too.