### PR TITLE
Fix absolute libdirpath builds

### DIFF
--- a/CMake/dcmtk.pc.in
+++ b/CMake/dcmtk.pc.in
@@ -1,6 +1,6 @@
  prefix="@CMAKE_INSTALL_PREFIX@"
  exec_prefix="${prefix}"
- libdir="${prefix}/@CMAKE_INSTALL_LIBDIR@"
+ libdir="@CMAKE_INSTALL_FULL_LIBDIR@"
  includedir="${prefix}/include/"
 
  Name: DCMTK

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,5 +210,5 @@ configure_file(
 )
 
 install(FILES "${DCMTK_BINARY_DIR}/dcmtk.pc"
-  DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )


### PR DESCRIPTION
This fixes builds where CMAKE_INSTALL_LIBDIR is absolute. This is the case on nixos (https://github.com/NixOS/nixpkgs/issues/144170)