### PR TITLE
Make it possible to specify MessageIDBeingRespondedTo for sendCANCELRequest.

### DIFF
--- a/dcmnet/include/dcmtk/dcmnet/scu.h
+++ b/dcmnet/include/dcmtk/dcmnet/scu.h
@@ -505,10 +505,11 @@ public:
      *  @param msgIDBeingRespondedTo [in] Optional message ID to respond with a C-CANCEL request.
      *                                    -1 means standard logic will take place. It should be
      *                                    provided when nextMessageId() is overridden.
+     *                                    The value should fit UINT16_MAX.
      *  @return The current implementation always returns EC_Normal.
      */
     virtual OFCondition sendCANCELRequest(const T_ASC_PresentationContextID presID,
-                                          const Sint16 msgIDBeingRespondedTo = -1);
+                                          const Sint32 msgIDBeingRespondedTo = -1);
 
     /** This function sends a N-ACTION request on the currently opened association and receives
      *  the corresponding response then

--- a/dcmnet/include/dcmtk/dcmnet/scu.h
+++ b/dcmnet/include/dcmtk/dcmnet/scu.h
@@ -502,9 +502,13 @@ public:
      *  class and usually only, if the last command send on that presentation context was a
      *  C-FIND message.
      *  @param presID [in] The presentation context ID where the C-CANCEL should be sent on.
+     *  @param msgIDBeingRespondedTo [in] Optional message ID to respond with a C-CANCEL request.
+     *                                    -1 means standard logic will take place. It should be
+     *                                    provided when nextMessageId() is overridden.
      *  @return The current implementation always returns EC_Normal.
      */
-    virtual OFCondition sendCANCELRequest(const T_ASC_PresentationContextID presID);
+    virtual OFCondition sendCANCELRequest(const T_ASC_PresentationContextID presID,
+                                          const Sint16 msgIDBeingRespondedTo = -1);
 
     /** This function sends a N-ACTION request on the currently opened association and receives
      *  the corresponding response then

--- a/dcmnet/libsrc/scu.cc
+++ b/dcmnet/libsrc/scu.cc
@@ -1614,10 +1614,13 @@ OFCondition DcmSCU::handleFINDResponse(const T_ASC_PresentationContextID /* pres
 
 // Send C-CANCEL-REQ and, therefore, ends current C-FIND, -MOVE or -GET session
 OFCondition DcmSCU::sendCANCELRequest(const T_ASC_PresentationContextID presID,
-                                      const Sint16 msgIDBeingRespondedTo)
+                                      const Sint32 msgIDBeingRespondedTo)
 {
     if (!isConnected())
         return DIMSE_ILLEGALASSOCIATION;
+
+    if (msgIDBeingRespondedTo > UINT16_MAX || msgIDBeingRespondedTo < -1)
+        return EC_IllegalParameter;
 
     /* Prepare DIMSE data structures for issuing request */
     OFCondition cond;
@@ -1632,7 +1635,7 @@ OFCondition DcmSCU::sendCANCELRequest(const T_ASC_PresentationContextID presID,
 
     if (msgIDBeingRespondedTo != -1)
     {
-        req->MessageIDBeingRespondedTo = msgIDBeingRespondedTo;
+        req->MessageIDBeingRespondedTo = OFstatic_cast(Uint16, msgIDBeingRespondedTo);
     }
     else
     {

--- a/dcmnet/libsrc/scu.cc
+++ b/dcmnet/libsrc/scu.cc
@@ -1613,7 +1613,8 @@ OFCondition DcmSCU::handleFINDResponse(const T_ASC_PresentationContextID /* pres
 /* ************************************************************************* */
 
 // Send C-CANCEL-REQ and, therefore, ends current C-FIND, -MOVE or -GET session
-OFCondition DcmSCU::sendCANCELRequest(const T_ASC_PresentationContextID presID)
+OFCondition DcmSCU::sendCANCELRequest(const T_ASC_PresentationContextID presID,
+                                      const Sint16 msgIDBeingRespondedTo)
 {
     if (!isConnected())
         return DIMSE_ILLEGALASSOCIATION;
@@ -1628,18 +1629,27 @@ OFCondition DcmSCU::sendCANCELRequest(const T_ASC_PresentationContextID presID)
     T_DIMSE_C_CancelRQ* req = &(msg.msg.CCancelRQ);
     // Set type of message
     msg.CommandField = DIMSE_C_CANCEL_RQ;
-    /* Set message ID responded to. A new message ID is _not_ needed so
-       we do not increment the message ID here but instead have to give the
-       message ID that was used last.
-       Note that that it is required to actually use the message ID of the last
-       C-FIND/GET/MOVE that was issued on this presentation context channel.
-       However, since we only support synchronous association mode so far,
-       it is enough to take the last message ID used at all.
-       For asynchronous operation, we would have to lookup the message ID
-       of the last C-FIND/GET/MOVE request issued and thus, store this
-       information after sending it.
-     */
-    req->MessageIDBeingRespondedTo = m_assoc->nextMsgID - 1;
+
+    if (msgIDBeingRespondedTo != -1)
+    {
+        req->MessageIDBeingRespondedTo = msgIDBeingRespondedTo;
+    }
+    else
+    {
+        /* Set message ID responded to. A new message ID is _not_ needed so
+           we do not increment the message ID here but instead have to give the
+           message ID that was used last.
+           Note that that it is required to actually use the message ID of the last
+           C-FIND/GET/MOVE that was issued on this presentation context channel.
+           However, since we only support synchronous association mode so far,
+           it is enough to take the last message ID used at all.
+           For asynchronous operation, we would have to lookup the message ID
+           of the last C-FIND/GET/MOVE request issued and thus, store this
+           information after sending it.
+         */
+        req->MessageIDBeingRespondedTo = m_assoc->nextMsgID - 1;
+    }
+
     // Announce dataset
     req->DataSetType = DIMSE_DATASET_NULL;
 


### PR DESCRIPTION
This is needed to be able to use sendCANCELRequest implementation from DcmSCU without overriding it when nextMessageId() is overridden.