### PR TITLE
Make JSON output valid even if "pixel data is encapsulated"

### DIFF
--- a/dcmdata/libsrc/dcpixel.cc
+++ b/dcmdata/libsrc/dcpixel.cc
@@ -1345,6 +1345,10 @@ OFCondition DcmPixelData::writeJson(STD_NAMESPACE ostream &out,
       return EC_Normal;
     }
 
+    /* write JSON Opener and Closer, because otherwise the output is not valid JSON */
+    writeJsonOpener(out, format);
+    writeJsonCloser(out, format);
+
     // pixel data is encapsulated, return error
     return EC_CannotWriteJsonInlineBinary;
 }


### PR DESCRIPTION
Problem: JSON output as a whole is not valid JSON when "pixel data is encapsulated" (whatever that means)

Solution: even in this case, write JSON Opener and Closer