### PR TITLE
logical error fix at computeMonochromeImageComparionMetricsRaw

### DIFF
--- a/dcmimage/libsrc/dcmicmph.cc
+++ b/dcmimage/libsrc/dcmicmph.cc
@@ -677,10 +677,10 @@ OFCondition DicomImageComparison::computeMonochromeImageComparionMetricsRaw()
         DCMIMAGE_DEBUG("square_error_sum: " << square_error_sum);
 
         // as a helper variable, divide the sum of squared errors by the total number of samples
-        double meanSquareError = square_error_sum / (numValues * fcount);
+        double meanSquareError = square_error_sum / numValuesfcount;
 
         // the mean absolute error is the sum of (unsigned) error values divided by the total number of samples
-        meanAbsoluteError = simple_error_sum / (numValues * fcount);
+        meanAbsoluteError = simple_error_sum / numValues;
 
         // RMSE is the square root of the mean square error
         rootMeanSquareError = sqrt(meanSquareError);


### PR DESCRIPTION
In the division to get the error, numValues is already multiplied by the frame count, resulting in a lower error value than it should be.