### PR TITLE
Update dcmtk.pc.in

### DIFF
--- a/CMake/dcmtk.pc.in
+++ b/CMake/dcmtk.pc.in
@@ -1,14 +1,14 @@
- prefix="@CMAKE_INSTALL_PREFIX@"
- exec_prefix="${prefix}"
- libdir="@CMAKE_INSTALL_FULL_LIBDIR@"
- includedir="${prefix}/include/"
+prefix="@CMAKE_INSTALL_PREFIX@"
+exec_prefix="${prefix}"
+libdir="@CMAKE_INSTALL_FULL_LIBDIR@"
+includedir="${prefix}/include/"
 
- Name: DCMTK
- Description: DICOM Toolkit (DCMTK)
- URL: https://dcmtk.org
- Version: @DCMTK_MAJOR_VERSION@.@DCMTK_MINOR_VERSION@.@DCMTK_BUILD_VERSION@
- Requires: @PKGCONF_REQ_PUB@
- Requires.private: @PKGCONF_REQ_PRIV@
- Cflags: -I"${includedir}"
- Libs: -L"${libdir}" @PKGCONF_LIBS@
- Libs.private: -L"${libdir}" @PKGCONF_LIBS_PRIV@
+Name: DCMTK
+Description: DICOM Toolkit (DCMTK)
+URL: https://dcmtk.org
+Version: @DCMTK_MAJOR_VERSION@.@DCMTK_MINOR_VERSION@.@DCMTK_BUILD_VERSION@
+Requires: @PKGCONF_REQ_PUB@
+Requires.private: @PKGCONF_REQ_PRIV@
+Cflags: -I"${includedir}"
+Libs: -L"${libdir}" @PKGCONF_LIBS@
+Libs.private: -L"${libdir}" @PKGCONF_LIBS_PRIV@


### PR DESCRIPTION
Hello, I'm a member of Microsoft VCPKG. When I install `dcmtk` by vcpkg after we updated the pkg-config to 1.8.0, I got below error:
```
Package dcmtk was not found in the pkg-config search path.
Perhaps you should add the directory containing `dcmtk.pc'
to the PKG_CONFIG_PATH environment variable
Package 'dcmtk', required by 'virtual:world', not found
```
Above error also could be reproduced by command:
`pkg-config.exe --print-errors --exists dcmtk --with-path={path of pc file}`

This issue occurred because there were leading spaces in the content of the pc file. After removing the spaces, the issue was resolved. 
```
 Name: DCMTK
 Description: DICOM Toolkit (DCMTK)
 URL: https://dcmtk.org
 Version: 3.6.7
```

To maintain consistent formatting, I removed all the spaces.