### PR TITLE
Unique filenames for files received with C-STORE

### DIFF
--- a/dcmqrdb/libsrc/dcmqrdbi.cc
+++ b/dcmqrdb/libsrc/dcmqrdbi.cc
@@ -3257,7 +3257,7 @@ OFCondition DcmQueryRetrieveIndexDatabaseHandle::makeNewStoreFileName(
     if (m==NULL) m = "XX";
     sprintf(prefix, "%s_", m);
     // unsigned int seed = fnamecreator.hashString(SOPInstanceUID);
-    unsigned int seed = (unsigned int)time(NULL);
+    static unsigned int seed = (unsigned int)time(NULL);
     newImageFileName[0]=0; // return empty string in case of error
     if (! fnamecreator.makeFilename(seed, handle_->storageArea, prefix, ".dcm", filename))
         return QR_EC_IndexDatabaseError;


### PR DESCRIPTION
The filename created by `OFFilenameCreator::makeFilename()` has the structure `MM_TTTTTTTTRRRRRRRR.dcm` where

	MM = modality prefix
	TTTTTTTT = creation_time (hex)
	RRRRRRRR = random value

currently all files with same `creation_time` have the RRRRRRRR suffix, seeded from current time (seconds resolution)

the function checks if the file exists and if so it retries up to MAX_TRY times with a different RRRRRRRR suffix until it finds an available filename.

PROBLEMS

1. this loop of retries for a unique filename works, but it gets executed for all filenames with an initial RRRRRRRR suffix seeded from the "same second" of time. This retry loop can possibly be avoided.

2. in the retry loop the fact that a file doesn't exist is not a guarantee that the particular filename hasn't been "requested" already, and maybe it will be created later. In my application linked with the DCMTK library `dcmqrdb` this is the case and all files, for example, received with C-STORE within the same second of time will overwrite each other.

PROPOSED SOLUTION

My proposed solution is to prepend the keyword `static` to the definition of `seed` as shown below,  so that it gets initialised only once ever, thereafter being modified by each successive call to `OFrand_r(seed)` in `fnamecreator.makeFilename(seed,,,,)`

	DcmQueryRetrieveIndexDatabaseHandle::makeNewStoreFileName()
	{
		// ...
		static
		unsigned int seed = (unsigned int)time(NULL);
		// ...
	}

Note that all this only affects the filename suffix part RRRRRRRR.