### PR TITLE
Fix "ambiguous overload for ‘operator==’" error if compiled with C++20

### DIFF
--- a/dcmqrdb/include/dcmtk/dcmqrdb/dcmqridx.h
+++ b/dcmqrdb/include/dcmtk/dcmqrdb/dcmqridx.h
@@ -122,9 +122,21 @@ struct DCMTK_DCMQRDB_EXPORT DB_SerializedTagKey
     inline DB_SerializedTagKey(const DcmTagKey& rhs) { *this = rhs; }
     inline DB_SerializedTagKey& operator=(const DcmTagKey& tk) { key[0] = tk.getGroup(); key[1] = tk.getElement(); return *this; }
     inline operator DcmTagKey() const { return DcmTagKey( key[0], key[1] ); }
-    inline bool operator==(const DB_SerializedTagKey& rhs) const { return key[0] == rhs.key[0] && key[1] == rhs.key[1]; }
     Uint16 key[2];
 };
+
+inline bool operator==(const DB_SerializedTagKey& lhs, const DB_SerializedTagKey& rhs)
+{
+    return lhs.key[0] == rhs.key[0] && lhs.key[1] == rhs.key[1];
+}
+inline bool operator==(const DB_SerializedTagKey& lhs, const DcmTagKey& rhs)
+{
+    return lhs == DB_SerializedTagKey(rhs);
+}
+inline bool operator==(const DcmTagKey& lhs, const DB_SerializedTagKey& rhs)
+{
+    return rhs == lhs;
+}
 
 /* ENSURE THAT DBVERSION IS INCREMENTED WHENEVER ONE OF THESE STRUCTS IS MODIFIED */
 

--- a/dcmqrdb/libsrc/dcmqrdbi.cc
+++ b/dcmqrdb/libsrc/dcmqrdbi.cc
@@ -1216,13 +1216,12 @@ OFCondition DcmQueryRetrieveIndexDatabaseHandle::hierarchicalCompare (
          */
 
         DB_GetUIDTag (level, &XTag) ;
-        const DB_SerializedTagKey XTagDBSerialized = XTag;
 
         /** Find Element with this XTag in Identifier list
          */
 
         for (plist = phandle->findRequestList ; plist ; plist = plist->next)
-            if (plist->elem. XTag == XTagDBSerialized)
+            if (plist->elem. XTag == XTag)
                 break ;
 
         /** Element not found
@@ -1238,7 +1237,7 @@ OFCondition DcmQueryRetrieveIndexDatabaseHandle::hierarchicalCompare (
          */
 
         for (i = 0 ; i < NBPARAMETERS ; i++)
-            if (idxRec->param [i]. XTag == XTagDBSerialized)
+            if (idxRec->param [i]. XTag == XTag)
                 break ;
 
         /** Compare with Single value matching
@@ -1371,8 +1370,7 @@ OFCondition DcmQueryRetrieveIndexDatabaseHandle::startFindRequest(
         DcmElement* dcelem = findRequestIdentifiers->getElement(elemIndex);
 
         elem.XTag = dcelem->getTag().getXTag();
-        const DB_SerializedTagKey DCM_QueryRetrieveLevelDBSerialized = DCM_QueryRetrieveLevel;
-        if (elem.XTag == DCM_QueryRetrieveLevelDBSerialized || DB_TagSupported(elem.XTag)) {
+        if (elem.XTag == DCM_QueryRetrieveLevel || DB_TagSupported(elem.XTag)) {
             elem.ValueLength = dcelem->getLength();
             if (elem.ValueLength == 0) {
                 elem.PValueField = NULL ;
@@ -1389,7 +1387,7 @@ OFCondition DcmQueryRetrieveIndexDatabaseHandle::startFindRequest(
             /** If element is the Query Level, store it in handle
              */
 
-            if (elem.XTag == DCM_QueryRetrieveLevelDBSerialized && elem.PValueField) {
+            if (elem.XTag == DCM_QueryRetrieveLevel && elem.PValueField) {
                 char *pc ;
                 char level [50] ;
 
@@ -2057,8 +2055,7 @@ OFCondition DcmQueryRetrieveIndexDatabaseHandle::startMoveRequest(
         DcmElement* dcelem = moveRequestIdentifiers->getElement(elemIndex);
 
         elem.XTag = dcelem->getTag().getXTag();
-        const DB_SerializedTagKey DCM_QueryRetrieveLevelDBSerialized = DCM_QueryRetrieveLevel;
-        if (elem.XTag == DCM_QueryRetrieveLevelDBSerialized || DB_TagSupported(elem.XTag)) {
+        if (elem.XTag == DCM_QueryRetrieveLevel || DB_TagSupported(elem.XTag)) {
             elem.ValueLength = dcelem->getLength();
             if (elem.ValueLength == 0) {
                 elem.PValueField = NULL ;
@@ -2076,7 +2073,7 @@ OFCondition DcmQueryRetrieveIndexDatabaseHandle::startMoveRequest(
             /** If element is the Query Level, store it in handle
              */
 
-            if (elem. XTag == DCM_QueryRetrieveLevelDBSerialized && elem.PValueField) {
+            if (elem. XTag == DCM_QueryRetrieveLevel && elem.PValueField) {
                 char *pc ;
                 char level [50] ;
 

--- a/dcmqrdb/libsrc/dcmqrdbi.cc
+++ b/dcmqrdb/libsrc/dcmqrdbi.cc
@@ -1216,12 +1216,13 @@ OFCondition DcmQueryRetrieveIndexDatabaseHandle::hierarchicalCompare (
          */
 
         DB_GetUIDTag (level, &XTag) ;
+        const DB_SerializedTagKey XTagDBSerialized = XTag;
 
         /** Find Element with this XTag in Identifier list
          */
 
         for (plist = phandle->findRequestList ; plist ; plist = plist->next)
-            if (plist->elem. XTag == XTag)
+            if (plist->elem. XTag == XTagDBSerialized)
                 break ;
 
         /** Element not found
@@ -1237,7 +1238,7 @@ OFCondition DcmQueryRetrieveIndexDatabaseHandle::hierarchicalCompare (
          */
 
         for (i = 0 ; i < NBPARAMETERS ; i++)
-            if (idxRec->param [i]. XTag == XTag)
+            if (idxRec->param [i]. XTag == XTagDBSerialized)
                 break ;
 
         /** Compare with Single value matching
@@ -1370,7 +1371,8 @@ OFCondition DcmQueryRetrieveIndexDatabaseHandle::startFindRequest(
         DcmElement* dcelem = findRequestIdentifiers->getElement(elemIndex);
 
         elem.XTag = dcelem->getTag().getXTag();
-        if (elem.XTag == DCM_QueryRetrieveLevel || DB_TagSupported(elem.XTag)) {
+        const DB_SerializedTagKey DCM_QueryRetrieveLevelDBSerialized = DCM_QueryRetrieveLevel;
+        if (elem.XTag == DCM_QueryRetrieveLevelDBSerialized || DB_TagSupported(elem.XTag)) {
             elem.ValueLength = dcelem->getLength();
             if (elem.ValueLength == 0) {
                 elem.PValueField = NULL ;
@@ -1387,7 +1389,7 @@ OFCondition DcmQueryRetrieveIndexDatabaseHandle::startFindRequest(
             /** If element is the Query Level, store it in handle
              */
 
-            if (elem.XTag == DCM_QueryRetrieveLevel && elem.PValueField) {
+            if (elem.XTag == DCM_QueryRetrieveLevelDBSerialized && elem.PValueField) {
                 char *pc ;
                 char level [50] ;
 
@@ -2055,7 +2057,8 @@ OFCondition DcmQueryRetrieveIndexDatabaseHandle::startMoveRequest(
         DcmElement* dcelem = moveRequestIdentifiers->getElement(elemIndex);
 
         elem.XTag = dcelem->getTag().getXTag();
-        if (elem.XTag == DCM_QueryRetrieveLevel || DB_TagSupported(elem.XTag)) {
+        const DB_SerializedTagKey DCM_QueryRetrieveLevelDBSerialized = DCM_QueryRetrieveLevel;
+        if (elem.XTag == DCM_QueryRetrieveLevelDBSerialized || DB_TagSupported(elem.XTag)) {
             elem.ValueLength = dcelem->getLength();
             if (elem.ValueLength == 0) {
                 elem.PValueField = NULL ;
@@ -2073,7 +2076,7 @@ OFCondition DcmQueryRetrieveIndexDatabaseHandle::startMoveRequest(
             /** If element is the Query Level, store it in handle
              */
 
-            if (elem. XTag == DCM_QueryRetrieveLevel && elem.PValueField) {
+            if (elem. XTag == DCM_QueryRetrieveLevelDBSerialized && elem.PValueField) {
                 char *pc ;
                 char level [50] ;
 


### PR DESCRIPTION
When you build dcmtk with C++20 and gcc 12, there are compilation errors, because compiler can't disambiguate between 2 `operator==` (the one of `DB_SerializedTagKey` and the one of `DcmTagKey`) when a `DB_SerializedTagKey` object is compared to a `DcmTagKey` in `dcmqrdbi.cc`. I've heard that C++20 was very strict and evaluates both a == b and b == a, and there must not be any ambiguity.

```
[687/1067] Building CXX object dcmqrdb/libsrc/CMakeFiles/dcmqrdb.dir/dcmqrdbi.cc.o
FAILED: dcmqrdb/libsrc/CMakeFiles/dcmqrdb.dir/dcmqrdbi.cc.o
/usr/bin/g++-12 -DDCMTK_BUILD_IN_PROGRESS -DDCMTK_HAVE_POLL=1 -DUSE_NULL_SAFE_OFSTRING -D_REENTRANT -Ddcmqrdb_EXPORTS -I/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/build/Release/config/include -I/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/ofstd/include -I/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/oflog/include -I/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmdata/include -I/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmimgle/include -I/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmimage/include -I/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmjpeg/include -I/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmjpls/include -I/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmtls/include -I/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmnet/include -I/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmsr/include -I/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmsign/include -I/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmwlm/include -I/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmqrdb/include -I/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmpstat/include -I/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmrt/include -I/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmiod/include -I/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmfg/include -I/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmseg/include -I/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmtract/include -I/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmpmap/include -I/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmect/include -I/home/spaceim/.conan2/p/b/libpn7fdcc8dbd0a67/p/include -I/home/spaceim/.conan2/p/b/opens9cdf8dceb09da/p/include -isystem /home/spaceim/.conan2/p/b/libxm1ee07b12fb925/p/include -isystem /home/spaceim/.conan2/p/b/libxm1ee07b12fb925/p/include/libxml2 -isystem /home/spaceim/.conan2/p/b/zlib5591cf988f5e0/p/include -isystem /home/spaceim/.conan2/p/b/libic102ca7b15de9b/p/include -m64 -fvisibility=hidden -D_XOPEN_SOURCE_EXTENDED -D_XOPEN_SOURCE=500 -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_BSD_COMPAT -D_OSF_SOURCE -D_POSIX_C_SOURCE=199506L -O3 -DNDEBUG -std=c++20 -fPIC -Wall -MD -MT dcmqrdb/libsrc/CMakeFiles/dcmqrdb.dir/dcmqrdbi.cc.o -MF dcmqrdb/libsrc/CMakeFiles/dcmqrdb.dir/dcmqrdbi.cc.o.d -o dcmqrdb/libsrc/CMakeFiles/dcmqrdb.dir/dcmqrdbi.cc.o -c /home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmqrdb/libsrc/dcmqrdbi.cc
/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmqrdb/libsrc/dcmqrdbi.cc: In member function ‘OFCondition DcmQueryRetrieveIndexDatabaseHandle::hierarchicalCompare(DB_Private_Handle*, IdxRecord*, DB_LEVEL, DB_LEVEL, int*, CharsetConsideringMatcher&)’:
/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmqrdb/libsrc/dcmqrdbi.cc:1224:35: error: ambiguous overload for ‘operator==’ (operand types are ‘DB_SerializedTagKey’ and ‘DcmTagKey’)
 1224 |             if (plist->elem. XTag == XTag)
      |                 ~~~~~~~~~~~~~~~~~ ^~ ~~~~
      |                              |       |
      |                              |       DcmTagKey
      |                              DB_SerializedTagKey
In file included from /home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmdata/include/dcmtk/dcmdata/dctag.h:27,
                 from /home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmdata/include/dcmtk/dcmdata/dcobject.h:33,
                 from /home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmdata/include/dcmtk/dcmdata/dcitem.h:30,
                 from /home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmdata/include/dcmtk/dcmdata/dcdatset.h:28,
                 from /home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmnet/include/dcmtk/dcmnet/dimse.h:93,
                 from /home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmqrdb/include/dcmtk/dcmqrdb/dcmqrdbi.h:29,
                 from /home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmqrdb/libsrc/dcmqrdbi.cc:40:
/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmdata/include/dcmtk/dcmdata/dctagkey.h:400:1: note: candidate: ‘OFBool DcmTagKey::operator==(const DcmTagKey&) const’ (reversed)
  400 | DcmTagKey::operator == (const DcmTagKey& key) const
      | ^~~~~~~~~
In file included from /home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmqrdb/libsrc/dcmqrdbi.cc:44:
/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmqrdb/include/dcmtk/dcmqrdb/dcmqridx.h:125:17: note: candidate: ‘bool DB_SerializedTagKey::operator==(const DB_SerializedTagKey&) const’
  125 |     inline bool operator==(const DB_SerializedTagKey& rhs) const { return key[0] == rhs.key[0] && key[1] == rhs.key[1]; }
      |                 ^~~~~~~~
/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmqrdb/libsrc/dcmqrdbi.cc:1240:41: error: ambiguous overload for ‘operator==’ (operand types are ‘DB_SerializedTagKey’ and ‘DcmTagKey’)
 1240 |             if (idxRec->param [i]. XTag == XTag)
      |                 ~~~~~~~~~~~~~~~~~~~~~~~ ^~ ~~~~
      |                                    |       |
      |                                    |       DcmTagKey
      |                                    DB_SerializedTagKey
/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmdata/include/dcmtk/dcmdata/dctagkey.h:400:1: note: candidate: ‘OFBool DcmTagKey::operator==(const DcmTagKey&) const’ (reversed)
  400 | DcmTagKey::operator == (const DcmTagKey& key) const
      | ^~~~~~~~~
/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmqrdb/include/dcmtk/dcmqrdb/dcmqridx.h:125:17: note: candidate: ‘bool DB_SerializedTagKey::operator==(const DB_SerializedTagKey&) const’
  125 |     inline bool operator==(const DB_SerializedTagKey& rhs) const { return key[0] == rhs.key[0] && key[1] == rhs.key[1]; }
      |                 ^~~~~~~~
/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmqrdb/libsrc/dcmqrdbi.cc: In member function ‘virtual OFCondition DcmQueryRetrieveIndexDatabaseHandle::startFindRequest(const char*, DcmDataset*, DcmQueryRetrieveDatabaseStatus*)’:
/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmqrdb/libsrc/dcmqrdbi.cc:1373:23: error: ambiguous overload for ‘operator==’ (operand types are ‘DB_SerializedTagKey’ and ‘DcmTagKey’)
 1373 |         if (elem.XTag == DCM_QueryRetrieveLevel || DB_TagSupported(elem.XTag)) {
      |             ~~~~~~~~~ ^~
      |                  |
      |                  DB_SerializedTagKey
/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmdata/include/dcmtk/dcmdata/dctagkey.h:400:1: note: candidate: ‘OFBool DcmTagKey::operator==(const DcmTagKey&) const’ (reversed)
  400 | DcmTagKey::operator == (const DcmTagKey& key) const
      | ^~~~~~~~~
/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmqrdb/include/dcmtk/dcmqrdb/dcmqridx.h:125:17: note: candidate: ‘bool DB_SerializedTagKey::operator==(const DB_SerializedTagKey&) const’
  125 |     inline bool operator==(const DB_SerializedTagKey& rhs) const { return key[0] == rhs.key[0] && key[1] == rhs.key[1]; }
      |                 ^~~~~~~~
/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmqrdb/libsrc/dcmqrdbi.cc:1390:27: error: ambiguous overload for ‘operator==’ (operand types are ‘DB_SerializedTagKey’ and ‘DcmTagKey’)
 1390 |             if (elem.XTag == DCM_QueryRetrieveLevel && elem.PValueField) {
      |                 ~~~~~~~~~ ^~
      |                      |
      |                      DB_SerializedTagKey
/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmdata/include/dcmtk/dcmdata/dctagkey.h:400:1: note: candidate: ‘OFBool DcmTagKey::operator==(const DcmTagKey&) const’ (reversed)
  400 | DcmTagKey::operator == (const DcmTagKey& key) const
      | ^~~~~~~~~
/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmqrdb/include/dcmtk/dcmqrdb/dcmqridx.h:125:17: note: candidate: ‘bool DB_SerializedTagKey::operator==(const DB_SerializedTagKey&) const’
  125 |     inline bool operator==(const DB_SerializedTagKey& rhs) const { return key[0] == rhs.key[0] && key[1] == rhs.key[1]; }
      |                 ^~~~~~~~
/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmqrdb/libsrc/dcmqrdbi.cc: In member function ‘virtual OFCondition DcmQueryRetrieveIndexDatabaseHandle::startMoveRequest(const char*, DcmDataset*, DcmQueryRetrieveDatabaseStatus*)’:
/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmqrdb/libsrc/dcmqrdbi.cc:2058:23: error: ambiguous overload for ‘operator==’ (operand types are ‘DB_SerializedTagKey’ and ‘DcmTagKey’)
 2058 |         if (elem.XTag == DCM_QueryRetrieveLevel || DB_TagSupported(elem.XTag)) {
      |             ~~~~~~~~~ ^~
      |                  |
      |                  DB_SerializedTagKey
/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmdata/include/dcmtk/dcmdata/dctagkey.h:400:1: note: candidate: ‘OFBool DcmTagKey::operator==(const DcmTagKey&) const’ (reversed)
  400 | DcmTagKey::operator == (const DcmTagKey& key) const
      | ^~~~~~~~~
/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmqrdb/include/dcmtk/dcmqrdb/dcmqridx.h:125:17: note: candidate: ‘bool DB_SerializedTagKey::operator==(const DB_SerializedTagKey&) const’
  125 |     inline bool operator==(const DB_SerializedTagKey& rhs) const { return key[0] == rhs.key[0] && key[1] == rhs.key[1]; }
      |                 ^~~~~~~~
/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmqrdb/libsrc/dcmqrdbi.cc:2076:28: error: ambiguous overload for ‘operator==’ (operand types are ‘DB_SerializedTagKey’ and ‘DcmTagKey’)
 2076 |             if (elem. XTag == DCM_QueryRetrieveLevel && elem.PValueField) {
      |                 ~~~~~~~~~~ ^~
      |                       |
      |                       DB_SerializedTagKey
/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmdata/include/dcmtk/dcmdata/dctagkey.h:400:1: note: candidate: ‘OFBool DcmTagKey::operator==(const DcmTagKey&) const’ (reversed)
  400 | DcmTagKey::operator == (const DcmTagKey& key) const
      | ^~~~~~~~~
/home/spaceim/.conan2/p/b/dcmtkb10d99cb5d6aa/b/src/dcmqrdb/include/dcmtk/dcmqrdb/dcmqridx.h:125:17: note: candidate: ‘bool DB_SerializedTagKey::operator==(const DB_SerializedTagKey&) const’
  125 |     inline bool operator==(const DB_SerializedTagKey& rhs) const { return key[0] == rhs.key[0] && key[1] == rhs.key[1]; }
      |                 ^~~~~~~~
```

This PR fixes this issue.