### PR TITLE
Remove a format-overflow warning in gcc

### DIFF
--- a/dcmimage/libsrc/diquant.cc
+++ b/dcmimage/libsrc/diquant.cc
@@ -181,7 +181,7 @@ OFCondition DcmQuant::createPaletteColorImage(
 
     if (frames > 1)
     {
-      char buf[20];
+      char buf[21];
       sprintf(buf, "%lu", frames);
       if (result.good()) result = target.putAndInsertString(DCM_NumberOfFrames, buf);
     }


### PR DESCRIPTION
Removes:

dcmtk/dcmimage/libsrc/diquant.cc: In static member function ‘static OFCondition DcmQuant::createPaletteColorImage(DicomImage&, DcmItem&, OFBool, OFBool, OFBool, Uint32, std::string&, DcmLargestDimensionType, DcmRepresentativeColorType)’: dcmtk/dcmimage/libsrc/diquant.cc:185:24: warning: ‘sprintf’ may write a terminating nul past the end of the destination [-Wformat-overflow=]
  185 |       sprintf(buf, "%lu", frames);
      |                        ^
dcmtk/dcmimage/libsrc/diquant.cc:185:14: note: ‘sprintf’ output between 2 and 21 bytes into a destination of size 20
  185 |       sprintf(buf, "%lu", frames);
      |       ~~~~~~~^~~~~~~~~~~~~~~~~~~~