### PR TITLE
movescu's --bit-preserving option is not respecting the --output-directory option (issue #1122)

### DIFF
--- a/dcmnet/apps/movescu.cc
+++ b/dcmnet/apps/movescu.cc
@@ -282,7 +282,7 @@ main(int argc, char *argv[])
       cmd.addOption("--prefer-mpeg4-2-3d",   "+x3",     "prefer MPEG4 AVC/H.264 HP / Level 4.2 TS (3D)");
       cmd.addOption("--prefer-mpeg4-2-st",   "+xo",     "prefer MPEG4 AVC/H.264 Stereo HP / Level 4.2 TS");
       cmd.addOption("--prefer-hevc",         "+x4",     "prefer HEVC/H.265 Main Profile / Level 5.1 TS");
-      cmd.addOption("--prefer-hevc10",       "+x5",     "prefer HEVC/H.265 Main 10 Profile / Level 5.1 TS");
+      cmd.addOption("--prefer-hevc10",       "+x5",     "prefer HEVC/H.265 Main 10 Profile / L5.1 TS");
       cmd.addOption("--prefer-rle",          "+xr",     "prefer RLE lossless TS");
 #ifdef WITH_ZLIB
       cmd.addOption("--prefer-deflated",     "+xd",     "prefer deflated explicit VR little endian TS");

--- a/dcmnet/apps/movescu.cc
+++ b/dcmnet/apps/movescu.cc
@@ -1429,6 +1429,11 @@ static OFCondition storeSCP(
         OFStandard::sanitizeFilename(imageFileName);
     }
 
+    // Generate target path to write data.
+    OFString ofname; // Store full path here
+    OFStandard::combineDirAndFilename(ofname, opt_outputDirectory, imageFileName, OFTrue /* allowEmptyDirName */);
+    OFLOG_DEBUG(movescuLogger, "Saving to: " << ofname);
+
     OFString temp_str;
     if (movescuLogger.isEnabledFor(OFLogger::DEBUG_LOG_LEVEL))
     {
@@ -1438,11 +1443,6 @@ static OFCondition storeSCP(
         OFLOG_INFO(movescuLogger, "Received Store Request (MsgID " << req->MessageID << ", "
             << dcmSOPClassUIDToModality(req->AffectedSOPClassUID, "OT") << ")");
     }
-    
-    /* create full path name for the output file */
-    OFString ofname;
-    OFStandard::combineDirAndFilename(ofname, opt_outputDirectory, imageFileName, OFTrue /* allowEmptyDirName */);
-    OFLOG_DEBUG(movescuLogger, "Saving to: " << ofname);
 
     StoreCallbackData callbackData;
     callbackData.assoc = assoc;

--- a/dcmnet/apps/movescu.cc
+++ b/dcmnet/apps/movescu.cc
@@ -1356,9 +1356,7 @@ storeSCPCallback(
        {
          StoreCallbackData *cbdata = OFstatic_cast(StoreCallbackData*, callbackData);
          /* create full path name for the output file */
-         OFString ofname;
-         OFStandard::combineDirAndFilename(ofname, opt_outputDirectory, cbdata->imageFileName, OFTrue /* allowEmptyDirName */);
-         OFLOG_DEBUG(movescuLogger, "Saving to: " << ofname);
+         OFString ofname = cbdata->imageFileName;
          if (OFStandard::fileExists(ofname))
          {
            OFLOG_WARN(movescuLogger, "DICOM file already exists, overwriting: " << ofname);
@@ -1446,7 +1444,7 @@ static OFCondition storeSCP(
 
     StoreCallbackData callbackData;
     callbackData.assoc = assoc;
-    callbackData.imageFileName = imageFileName;
+    callbackData.imageFileName = ofname.c_str();
     DcmFileFormat dcmff;
     callbackData.dcmff = &dcmff;
 
@@ -1474,11 +1472,11 @@ static OFCondition storeSCP(
       /* remove file */
       if (!opt_ignore)
       {
-        if (strcmp(imageFileName, NULL_DEVICE_NAME) != 0) OFStandard::deleteFile(imageFileName);
+        if (strcmp(imageFileName, NULL_DEVICE_NAME) != 0) OFStandard::deleteFile(ofname.c_str());
       }
 #ifdef _WIN32
     } else if (opt_ignore) {
-        if (strcmp(imageFileName, NULL_DEVICE_NAME) != 0) OFStandard::deleteFile(imageFileName); // delete the temporary file
+        if (strcmp(imageFileName, NULL_DEVICE_NAME) != 0) OFStandard::deleteFile(ofname.c_str()); // delete the temporary file
 #endif
     }
 

--- a/dcmnet/apps/movescu.cc
+++ b/dcmnet/apps/movescu.cc
@@ -1472,11 +1472,17 @@ static OFCondition storeSCP(
       /* remove file */
       if (!opt_ignore)
       {
-        if (strcmp(imageFileName, NULL_DEVICE_NAME) != 0) OFStandard::deleteFile(ofname.c_str());
+        if (strcmp(imageFileName, NULL_DEVICE_NAME) != 0) 
+        {
+          OFStandard::deleteFile(ofname.c_str());
+        }
       }
 #ifdef _WIN32
     } else if (opt_ignore) {
-        if (strcmp(imageFileName, NULL_DEVICE_NAME) != 0) OFStandard::deleteFile(ofname.c_str()); // delete the temporary file
+        if (strcmp(imageFileName, NULL_DEVICE_NAME) != 0) 
+        {
+          OFStandard::deleteFile(ofname.c_str()); // delete the temporary file
+        }
 #endif
     }
 

--- a/dcmnet/apps/movescu.cc
+++ b/dcmnet/apps/movescu.cc
@@ -1358,6 +1358,7 @@ storeSCPCallback(
          /* create full path name for the output file */
          OFString ofname;
          OFStandard::combineDirAndFilename(ofname, opt_outputDirectory, cbdata->imageFileName, OFTrue /* allowEmptyDirName */);
+         OFLOG_DEBUG(movescuLogger, "Saving to: " << ofname);
          if (OFStandard::fileExists(ofname))
          {
            OFLOG_WARN(movescuLogger, "DICOM file already exists, overwriting: " << ofname);
@@ -1437,6 +1438,11 @@ static OFCondition storeSCP(
         OFLOG_INFO(movescuLogger, "Received Store Request (MsgID " << req->MessageID << ", "
             << dcmSOPClassUIDToModality(req->AffectedSOPClassUID, "OT") << ")");
     }
+    
+    /* create full path name for the output file */
+    OFString ofname;
+    OFStandard::combineDirAndFilename(ofname, opt_outputDirectory, imageFileName, OFTrue /* allowEmptyDirName */);
+    OFLOG_DEBUG(movescuLogger, "Saving to: " << ofname);
 
     StoreCallbackData callbackData;
     callbackData.assoc = assoc;
@@ -1455,7 +1461,7 @@ static OFCondition storeSCP(
 
     if (opt_bitPreserving)
     {
-      cond = DIMSE_storeProvider(assoc, presID, req, imageFileName, opt_useMetaheader,
+      cond = DIMSE_storeProvider(assoc, presID, req, ofname.c_str(), opt_useMetaheader,
         NULL, storeSCPCallback, OFreinterpret_cast(void*, &callbackData), opt_blockMode, opt_dimse_timeout);
     } else {
       cond = DIMSE_storeProvider(assoc, presID, req, NULL, opt_useMetaheader,

--- a/dcmnet/apps/movescu.cc
+++ b/dcmnet/apps/movescu.cc
@@ -282,7 +282,7 @@ main(int argc, char *argv[])
       cmd.addOption("--prefer-mpeg4-2-3d",   "+x3",     "prefer MPEG4 AVC/H.264 HP / Level 4.2 TS (3D)");
       cmd.addOption("--prefer-mpeg4-2-st",   "+xo",     "prefer MPEG4 AVC/H.264 Stereo HP / Level 4.2 TS");
       cmd.addOption("--prefer-hevc",         "+x4",     "prefer HEVC/H.265 Main Profile / Level 5.1 TS");
-      cmd.addOption("--prefer-hevc10",       "+x5",     "prefer HEVC/H.265 Main 10 Profile / L5.1 TS");
+      cmd.addOption("--prefer-hevc10",       "+x5",     "prefer HEVC/H.265 Main 10 Profile / Level 5.1 TS");
       cmd.addOption("--prefer-rle",          "+xr",     "prefer RLE lossless TS");
 #ifdef WITH_ZLIB
       cmd.addOption("--prefer-deflated",     "+xd",     "prefer deflated explicit VR little endian TS");
@@ -1285,7 +1285,7 @@ static OFCondition echoSCP(
 
 struct StoreCallbackData
 {
-    char *imageFileName;
+    const char *imageFileName;
     DcmFileFormat *dcmff;
     T_ASC_Association *assoc;
 };
@@ -1356,7 +1356,7 @@ storeSCPCallback(
        {
          StoreCallbackData *cbdata = OFstatic_cast(StoreCallbackData*, callbackData);
          /* create full path name for the output file */
-         OFString ofname = cbdata->imageFileName;
+         OFString ofname(cbdata->imageFileName);
          if (OFStandard::fileExists(ofname))
          {
            OFLOG_WARN(movescuLogger, "DICOM file already exists, overwriting: " << ofname);

--- a/dcmnet/apps/storescp.cc
+++ b/dcmnet/apps/storescp.cc
@@ -2024,6 +2024,7 @@ static OFCondition storeSCP(
       char buf[70];
       dcmGenerateUniqueIdentifier(buf);
       OFStandard::snprintf(imageFileName, sizeof(imageFileName), "%s%c%s.X.%s%s", opt_outputDirectory.c_str(), PATH_SEPARATOR,
+        dcmSOPClassUIDToModality(req->AffectedSOPClassUID, "UNKNOWN"),
         buf, opt_fileNameExtension.c_str());
     }
     else if (opt_timeNames)

--- a/dcmnet/apps/storescp.cc
+++ b/dcmnet/apps/storescp.cc
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (C) 1994-2022, OFFIS e.V.
+ *  Copyright (C) 1994-2024, OFFIS e.V.
  *  All rights reserved.  See COPYRIGHT file for details.
  *
  *  This software and supporting documentation were developed by
@@ -28,10 +28,9 @@ BEGIN_EXTERN_C
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>       /* needed on Solaris for O_RDONLY */
 #endif
-#ifdef HAVE_SIGNAL_H
+
 // On Solaris with Sun Workshop 11, <signal.h> declares signal() but <csignal> does not
 #include <signal.h>
-#endif
 END_EXTERN_C
 
 #include <cerrno>
@@ -58,7 +57,7 @@ END_EXTERN_C
 #include "dcmtk/dcmdata/dcuid.h"        /* for dcmtk version name */
 #include "dcmtk/dcmdata/dcdeftag.h"
 #include "dcmtk/dcmdata/dcostrmz.h"     /* for dcmZlibCompressionLevel */
-#include "dcmtk/dcmtls/tlsopt.h"      /* for DcmTLSOptions */
+#include "dcmtk/dcmtls/tlsopt.h"        /* for DcmTLSOptions */
 
 #ifdef WITH_ZLIB
 #include <zlib.h>        /* for zlibVersion() */
@@ -99,6 +98,7 @@ static void renameOnEndOfStudy();
 static OFString replaceChars( const OFString &srcstr, const OFString &pattern, const OFString &substitute );
 static void executeCommand( const OFString &cmd );
 static void cleanChildren(pid_t pid, OFBool synch);
+static void sanitizeAETitle(OFString& aet);
 static OFCondition acceptUnknownContextsWithPreferredTransferSyntaxes(
          T_ASC_Parameters * params,
          const char* transferSyntaxes[],
@@ -178,11 +178,7 @@ OFBool             opt_execSync = OFFalse;            // default: execute in bac
 /** signal handler for SIGCHLD signals that immediately cleans up
  *  terminated children.
  */
-#ifdef SIGNAL_HANDLER_WITH_ELLIPSE
-extern "C" void sigChildHandler(...)
-#else
 extern "C" void sigChildHandler(int)
-#endif
 {
   int status = 0;
   waitpid( -1, &status, WNOHANG );
@@ -260,7 +256,7 @@ int main(int argc, char *argv[])
       cmd.addOption("--prefer-mpeg4-2-3d",      "+x3",     "prefer MPEG4 AVC/H.264 HP / Level 4.2 TS (3D)");
       cmd.addOption("--prefer-mpeg4-2-st",      "+xo",     "prefer MPEG4 AVC/H.264 Stereo HP / Level 4.2 TS");
       cmd.addOption("--prefer-hevc",            "+x4",     "prefer HEVC/H.265 Main Profile / Level 5.1 TS");
-      cmd.addOption("--prefer-hevc10",          "+x5",     "prefer HEVC/H.265 Main 10 Profile / Level 5.1 TS");
+      cmd.addOption("--prefer-hevc10",          "+x5",     "prefer HEVC/H.265 Main 10 Profile / L5.1 TS");
       cmd.addOption("--prefer-rle",             "+xr",     "prefer RLE lossless TS");
 #ifdef WITH_ZLIB
       cmd.addOption("--prefer-deflated",        "+xd",     "prefer deflated expl. VR little endian TS");
@@ -1008,9 +1004,10 @@ static OFCondition acceptAssociation(T_ASC_Network *net, DcmAssociationConfigura
     UID_VerificationSOPClass
   };
 
-  const char* transferSyntaxes[] = { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,  // 10
-                                     NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,  // 20
-                                     NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL };            // +8
+  const char* transferSyntaxes[] = { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,   // 10
+                                     NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,   // 20
+                                     NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,   // 30
+                                     NULL };                                                       // +1
   int numTransferSyntaxes = 0;
 
   // try to receive an association. Here we either want to use blocking or
@@ -1302,17 +1299,20 @@ static OFCondition acceptAssociation(T_ASC_Network *net, DcmAssociationConfigura
         transferSyntaxes[21] = UID_FragmentableMPEG4StereoHighProfileLevel4_2TransferSyntax;
         transferSyntaxes[22] = UID_HEVCMainProfileLevel5_1TransferSyntax;
         transferSyntaxes[23] = UID_HEVCMain10ProfileLevel5_1TransferSyntax;
-        transferSyntaxes[24] = UID_DeflatedExplicitVRLittleEndianTransferSyntax;
+        transferSyntaxes[24] = UID_HighThroughputJPEG2000ImageCompressionLosslessOnlyTransferSyntax;
+        transferSyntaxes[25] = UID_HighThroughputJPEG2000RPCLImageCompressionLosslessOnlyTransferSyntax;
+        transferSyntaxes[26] = UID_HighThroughputJPEG2000ImageCompressionTransferSyntax;
+        transferSyntaxes[27] = UID_DeflatedExplicitVRLittleEndianTransferSyntax;
         if (gLocalByteOrder == EBO_LittleEndian)
         {
-          transferSyntaxes[25] = UID_LittleEndianExplicitTransferSyntax;
-          transferSyntaxes[26] = UID_BigEndianExplicitTransferSyntax;
+          transferSyntaxes[28] = UID_LittleEndianExplicitTransferSyntax;
+          transferSyntaxes[29] = UID_BigEndianExplicitTransferSyntax;
         } else {
-          transferSyntaxes[25] = UID_BigEndianExplicitTransferSyntax;
-          transferSyntaxes[26] = UID_LittleEndianExplicitTransferSyntax;
+          transferSyntaxes[28] = UID_BigEndianExplicitTransferSyntax;
+          transferSyntaxes[29] = UID_LittleEndianExplicitTransferSyntax;
         }
-        transferSyntaxes[27] = UID_LittleEndianImplicitTransferSyntax;
-        numTransferSyntaxes = 28;
+        transferSyntaxes[30] = UID_LittleEndianImplicitTransferSyntax;
+        numTransferSyntaxes = 31;
       } else {
         /* We prefer explicit transfer syntaxes.
          * If we are running on a Little Endian machine we prefer
@@ -2198,6 +2198,33 @@ static void executeEndOfStudyEvents()
   lastStudySubdirectoryPathAndName.clear();
 }
 
+/* replace all characters that might be interpreted by the shell with underscores
+ */
+static void sanitizeAETitle(OFString& aet)
+{
+  static const char sanitized_aetitle_charset[] =
+  {
+    ' ', '_', '_', '_', '_', '_', '_', '_', '_', '_', '_', '_', '_', '-', '.', '_',
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', ':', '_', '_', '_', '_', '_',
+    '@', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O',
+    'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '_', '_', '_', '_', '_',
+    '_', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o',
+    'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '_', '_', '_', '_', '_'
+  };
+
+  // the aet string starts and ends with quotation marks. We ignore these.
+  size_t len = aet.length();
+  if (len < 3) return;
+
+  char c;
+  --len;
+  for (size_t i=1; i < len; ++i)
+  {
+    c = aet[i];
+    if (c != 0 && (c < 32 || c >= 127)) c = '_'; else c = sanitized_aetitle_charset[c-32];
+    aet[i] = c;
+  }
+}
 
 static void executeOnReception()
     /*
@@ -2214,6 +2241,7 @@ static void executeOnReception()
      */
 {
   OFString cmd = opt_execOnReception;
+  OFString s;
 
   // in case a file was actually written
   if( !opt_ignore )
@@ -2229,10 +2257,22 @@ static void executeOnReception()
   }
 
   // perform substitution for placeholder #a
-  cmd = replaceChars( cmd, OFString(CALLING_AETITLE_PLACEHOLDER), callingAETitle );
+  s = callingAETitle;
+  sanitizeAETitle(s);
+  if (s != callingAETitle)
+  {
+    OFLOG_WARN(storescpLogger, "Sanitized unusual characters in calling aetitle, converted from " << callingAETitle << " to " << s << ".");
+  }
+  cmd = replaceChars( cmd, OFString(CALLING_AETITLE_PLACEHOLDER), s );
 
   // perform substitution for placeholder #c
-  cmd = replaceChars( cmd, OFString(CALLED_AETITLE_PLACEHOLDER), calledAETitle );
+  s = calledAETitle;
+  sanitizeAETitle(s);
+  if (s != calledAETitle)
+  {
+    OFLOG_WARN(storescpLogger, "Sanitized unusual characters in called aetitle, converted from " << calledAETitle << " to " << s << ".");
+  }
+  cmd = replaceChars( cmd, OFString(CALLED_AETITLE_PLACEHOLDER), s );
 
   // perform substitution for placeholder #r
   cmd = replaceChars( cmd, OFString(CALLING_PRESENTATION_ADDRESS_PLACEHOLDER), callingPresentationAddress );
@@ -2337,15 +2377,20 @@ static void executeOnEndOfStudy()
      */
 {
   OFString cmd = opt_execOnEndOfStudy;
+  OFString s;
 
   // perform substitution for placeholder #p; #p will be substituted by lastStudySubdirectoryPathAndName
   cmd = replaceChars( cmd, OFString(PATH_PLACEHOLDER), lastStudySubdirectoryPathAndName );
 
   // perform substitution for placeholder #a
-  cmd = replaceChars( cmd, OFString(CALLING_AETITLE_PLACEHOLDER), callingAETitle );
+  s = callingAETitle;
+  sanitizeAETitle(s);
+  cmd = replaceChars( cmd, OFString(CALLING_AETITLE_PLACEHOLDER), s );
 
   // perform substitution for placeholder #c
-  cmd = replaceChars( cmd, OFString(CALLED_AETITLE_PLACEHOLDER), calledAETitle );
+  s = calledAETitle;
+  sanitizeAETitle(s);
+  cmd = replaceChars( cmd, OFString(CALLED_AETITLE_PLACEHOLDER), s );
 
   // perform substitution for placeholder #r
   cmd = replaceChars( cmd, OFString(CALLING_PRESENTATION_ADDRESS_PLACEHOLDER), callingPresentationAddress );
@@ -2443,8 +2488,6 @@ static void executeCommand( const OFString &cmd )
 
 #ifdef HAVE_WAITPID
 static void cleanChildren(pid_t pid, OFBool synch)
-#elif defined(HAVE_WAIT3)
-static void cleanChildren(pid_t /* pid */, OFBool synch)
 #else
 static void cleanChildren(pid_t /* pid */, OFBool /* synch */)
 #endif
@@ -2455,26 +2498,11 @@ static void cleanChildren(pid_t /* pid */, OFBool /* synch */)
 {
 #ifdef HAVE_WAITPID
   int stat_loc;
-#elif defined(HAVE_WAIT3)
-  struct rusage rusage;
-#if defined(__NeXT__)
-  /* some systems need a union wait as argument to wait3 */
-  union wait status;
-#else
-  int        status;
-#endif
-#endif
-
-#if defined(HAVE_WAITPID) || defined(HAVE_WAIT3)
   int child = 1;
   int options = synch ? 0 : WNOHANG;
   while (child > 0)
   {
-#ifdef HAVE_WAITPID
     child = OFstatic_cast(int, waitpid(pid, &stat_loc, options));
-#elif defined(HAVE_WAIT3)
-    child = wait3(&status, options, &rusage);
-#endif
     if (child < 0)
     {
       if (errno != ECHILD)

--- a/dcmnet/apps/storescp.cc
+++ b/dcmnet/apps/storescp.cc
@@ -2023,7 +2023,7 @@ static OFCondition storeSCP(
       // create unique filename by generating a temporary UID and using ".X." as an infix
       char buf[70];
       dcmGenerateUniqueIdentifier(buf);
-      sprintf(imageFileName, "%s.X.%s%s", dcmSOPClassUIDToModality(req->AffectedSOPClassUID, "UNKNOWN"),
+      OFStandard::snprintf(imageFileName, sizeof(imageFileName), "%s%c%s.X.%s%s", opt_outputDirectory.c_str(), PATH_SEPARATOR,
         buf, opt_fileNameExtension.c_str());
     }
     else if (opt_timeNames)

--- a/dcmnet/apps/storescp.cc
+++ b/dcmnet/apps/storescp.cc
@@ -2056,7 +2056,7 @@ static OFCondition storeSCP(
         // if this is not the first run and the prospective filename is equal to the last written filename
         // generate one with a serial number (incremented by 1)
         timeNameCounter++;
-        sprintf(imageFileName, "%04u%02u%02u%02u%02u%02u%03u_%04u.%s%s", // millisecond version
+        OFStandard::snprintf(imageFileName, sizeof(imageFileName), "%s%c%04u%02u%02u%02u%02u%02u%03u_%04u.%s%s", opt_outputDirectory.c_str(), PATH_SEPARATOR, // millisecond version
           dateTime.getDate().getYear(), dateTime.getDate().getMonth(), dateTime.getDate().getDay(),
           dateTime.getTime().getHour(), dateTime.getTime().getMinute(), dateTime.getTime().getIntSecond(), dateTime.getTime().getMilliSecond(),
           timeNameCounter, dcmSOPClassUIDToModality(req->AffectedSOPClassUID, "UNKNOWN"), opt_fileNameExtension.c_str());
@@ -2064,7 +2064,7 @@ static OFCondition storeSCP(
       else
       {
         // first run or filenames are different: create filename without serial number
-        sprintf(imageFileName, "%04u%02u%02u%02u%02u%02u%03u.%s%s", // millisecond version
+        OFStandard::snprintf(imageFileName, sizeof(imageFileName), "%s%c%04u%02u%02u%02u%02u%02u%03u.%s%s", opt_outputDirectory.c_str(), PATH_SEPARATOR, // millisecond version
           dateTime.getDate().getYear(), dateTime.getDate().getMonth(), dateTime.getDate().getDay(),
           dateTime.getTime().getHour(), dateTime.getTime().getMinute(),dateTime.getTime().getIntSecond(), dateTime.getTime().getMilliSecond(),
           dcmSOPClassUIDToModality(req->AffectedSOPClassUID, "UNKNOWN"), opt_fileNameExtension.c_str());
@@ -2077,7 +2077,7 @@ static OFCondition storeSCP(
       // Use the SOP instance UID as found in the C-STORE request message as part of the filename
       OFString uid(OFSTRING_GUARD(req->AffectedSOPInstanceUID));
       OFStandard::sanitizeFilename(uid);
-      sprintf(imageFileName, "%s.%s%s", dcmSOPClassUIDToModality(req->AffectedSOPClassUID, "UNKNOWN"),
+      OFStandard::snprintf(imageFileName, sizeof(imageFileName), "%s%c%s.%s%s", opt_outputDirectory.c_str(), PATH_SEPARATOR, dcmSOPClassUIDToModality(req->AffectedSOPClassUID, "UNKNOWN"),
         uid.c_str(), opt_fileNameExtension.c_str());
     }
   }

--- a/dcmnet/apps/storescp.cc
+++ b/dcmnet/apps/storescp.cc
@@ -2006,10 +2006,7 @@ static OFCondition storeSCP(
   // if opt_ignore is set, the user requires that the data shall be received but not
   // stored. in this case, we want to create a corresponding temporary filename for
   // a file in which the data shall be stored temporarily. If this is not the case,
-  // create a real filename (consisting of path and filename) for a real file.
-    
-  OFString ofname; // store full path for the output file here
-         
+  // create a real filename (consisting of path and filename) for a real file.         
   if (opt_ignore)
   {
 #ifdef _WIN32
@@ -2086,8 +2083,9 @@ static OFCondition storeSCP(
   }
 
   // Combine file name and outdir into one path.
+  OFString ofname; // store full path for the output file here
   OFStandard::combineDirAndFilename(ofname, opt_outputDirectory, imageFileName, OFTrue /* allowEmptyDirName */);
-  OFLOG_INFO(movescuLogger, "Saving to: " << ofname);
+  OFLOG_DEBUG(storescpLogger, "Saving to: " << ofname);
 
   // dump some information if required
   OFString str;
@@ -2103,7 +2101,7 @@ static OFCondition storeSCP(
   // initialize some variables
   StoreCallbackData callbackData;
   callbackData.assoc = assoc;
-  callbackData.imageFileName = imageFileName;
+  callbackData.imageFileName = ofname.c_str();
   DcmFileFormat dcmff;
   callbackData.dcmff = &dcmff;
 
@@ -2140,14 +2138,14 @@ static OFCondition storeSCP(
     if (!opt_ignore)
     {
       if (strcmp(imageFileName, NULL_DEVICE_NAME) != 0)
-        OFStandard::deleteFile(imageFileName);
+        OFStandard::deleteFile(ofname.c_str());
     }
   }
 #ifdef _WIN32
   else if (opt_ignore)
   {
     if (strcmp(imageFileName, NULL_DEVICE_NAME) != 0)
-      OFStandard::deleteFile(imageFileName); // delete the temporary file
+      OFStandard::deleteFile(ofname.c_str()); // delete the temporary file
   }
 #endif
 

--- a/dcmnet/apps/storescp.cc
+++ b/dcmnet/apps/storescp.cc
@@ -2083,11 +2083,6 @@ static OFCondition storeSCP(
     }
   }
 
-  // Combine file name and outdir into one path.
-  OFString ofname; // store full path for the output file here
-  OFStandard::combineDirAndFilename(ofname, opt_outputDirectory, imageFileName, OFTrue /* allowEmptyDirName */);
-  OFLOG_DEBUG(storescpLogger, "Saving to: " << ofname);
-
   // dump some information if required
   OFString str;
   if (storescpLogger.isEnabledFor(OFLogger::DEBUG_LOG_LEVEL))
@@ -2102,7 +2097,7 @@ static OFCondition storeSCP(
   // initialize some variables
   StoreCallbackData callbackData;
   callbackData.assoc = assoc;
-  callbackData.imageFileName = ofname.c_str();
+  callbackData.imageFileName = imageFileName;
   DcmFileFormat dcmff;
   callbackData.dcmff = &dcmff;
 
@@ -2121,7 +2116,7 @@ static OFCondition storeSCP(
   // DIMSE_storeProvider must be called with certain parameters.
   if (opt_bitPreserving)
   {
-    cond = DIMSE_storeProvider(assoc, presID, req, ofname.c_str(), opt_useMetaheader, NULL,
+    cond = DIMSE_storeProvider(assoc, presID, req, imageFileName, opt_useMetaheader, NULL,
       storeSCPCallback, &callbackData, opt_blockMode, opt_dimse_timeout);
   }
   else
@@ -2139,14 +2134,18 @@ static OFCondition storeSCP(
     if (!opt_ignore)
     {
       if (strcmp(imageFileName, NULL_DEVICE_NAME) != 0)
-        OFStandard::deleteFile(ofname.c_str());
+      {
+         OFStandard::deleteFile(imageFileName);
+      }
     }
   }
 #ifdef _WIN32
   else if (opt_ignore)
   {
     if (strcmp(imageFileName, NULL_DEVICE_NAME) != 0)
-      OFStandard::deleteFile(ofname.c_str()); // delete the temporary file
+    {
+        OFStandard::deleteFile(imageFileName); // delete the temporary file
+    }
   }
 #endif
 

--- a/dcmnet/apps/storescp.cc
+++ b/dcmnet/apps/storescp.cc
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (C) 1994-2024, OFFIS e.V.
+ *  Copyright (C) 1994-2022, OFFIS e.V.
  *  All rights reserved.  See COPYRIGHT file for details.
  *
  *  This software and supporting documentation were developed by
@@ -28,9 +28,10 @@ BEGIN_EXTERN_C
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>       /* needed on Solaris for O_RDONLY */
 #endif
-
+#ifdef HAVE_SIGNAL_H
 // On Solaris with Sun Workshop 11, <signal.h> declares signal() but <csignal> does not
 #include <signal.h>
+#endif
 END_EXTERN_C
 
 #include <cerrno>
@@ -57,7 +58,7 @@ END_EXTERN_C
 #include "dcmtk/dcmdata/dcuid.h"        /* for dcmtk version name */
 #include "dcmtk/dcmdata/dcdeftag.h"
 #include "dcmtk/dcmdata/dcostrmz.h"     /* for dcmZlibCompressionLevel */
-#include "dcmtk/dcmtls/tlsopt.h"        /* for DcmTLSOptions */
+#include "dcmtk/dcmtls/tlsopt.h"      /* for DcmTLSOptions */
 
 #ifdef WITH_ZLIB
 #include <zlib.h>        /* for zlibVersion() */
@@ -98,7 +99,6 @@ static void renameOnEndOfStudy();
 static OFString replaceChars( const OFString &srcstr, const OFString &pattern, const OFString &substitute );
 static void executeCommand( const OFString &cmd );
 static void cleanChildren(pid_t pid, OFBool synch);
-static void sanitizeAETitle(OFString& aet);
 static OFCondition acceptUnknownContextsWithPreferredTransferSyntaxes(
          T_ASC_Parameters * params,
          const char* transferSyntaxes[],
@@ -178,7 +178,11 @@ OFBool             opt_execSync = OFFalse;            // default: execute in bac
 /** signal handler for SIGCHLD signals that immediately cleans up
  *  terminated children.
  */
+#ifdef SIGNAL_HANDLER_WITH_ELLIPSE
+extern "C" void sigChildHandler(...)
+#else
 extern "C" void sigChildHandler(int)
+#endif
 {
   int status = 0;
   waitpid( -1, &status, WNOHANG );
@@ -256,7 +260,7 @@ int main(int argc, char *argv[])
       cmd.addOption("--prefer-mpeg4-2-3d",      "+x3",     "prefer MPEG4 AVC/H.264 HP / Level 4.2 TS (3D)");
       cmd.addOption("--prefer-mpeg4-2-st",      "+xo",     "prefer MPEG4 AVC/H.264 Stereo HP / Level 4.2 TS");
       cmd.addOption("--prefer-hevc",            "+x4",     "prefer HEVC/H.265 Main Profile / Level 5.1 TS");
-      cmd.addOption("--prefer-hevc10",          "+x5",     "prefer HEVC/H.265 Main 10 Profile / L5.1 TS");
+      cmd.addOption("--prefer-hevc10",          "+x5",     "prefer HEVC/H.265 Main 10 Profile / Level 5.1 TS");
       cmd.addOption("--prefer-rle",             "+xr",     "prefer RLE lossless TS");
 #ifdef WITH_ZLIB
       cmd.addOption("--prefer-deflated",        "+xd",     "prefer deflated expl. VR little endian TS");
@@ -1004,10 +1008,9 @@ static OFCondition acceptAssociation(T_ASC_Network *net, DcmAssociationConfigura
     UID_VerificationSOPClass
   };
 
-  const char* transferSyntaxes[] = { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,   // 10
-                                     NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,   // 20
-                                     NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,   // 30
-                                     NULL };                                                       // +1
+  const char* transferSyntaxes[] = { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,  // 10
+                                     NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,  // 20
+                                     NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL };            // +8
   int numTransferSyntaxes = 0;
 
   // try to receive an association. Here we either want to use blocking or
@@ -1299,20 +1302,17 @@ static OFCondition acceptAssociation(T_ASC_Network *net, DcmAssociationConfigura
         transferSyntaxes[21] = UID_FragmentableMPEG4StereoHighProfileLevel4_2TransferSyntax;
         transferSyntaxes[22] = UID_HEVCMainProfileLevel5_1TransferSyntax;
         transferSyntaxes[23] = UID_HEVCMain10ProfileLevel5_1TransferSyntax;
-        transferSyntaxes[24] = UID_HighThroughputJPEG2000ImageCompressionLosslessOnlyTransferSyntax;
-        transferSyntaxes[25] = UID_HighThroughputJPEG2000RPCLImageCompressionLosslessOnlyTransferSyntax;
-        transferSyntaxes[26] = UID_HighThroughputJPEG2000ImageCompressionTransferSyntax;
-        transferSyntaxes[27] = UID_DeflatedExplicitVRLittleEndianTransferSyntax;
+        transferSyntaxes[24] = UID_DeflatedExplicitVRLittleEndianTransferSyntax;
         if (gLocalByteOrder == EBO_LittleEndian)
         {
-          transferSyntaxes[28] = UID_LittleEndianExplicitTransferSyntax;
-          transferSyntaxes[29] = UID_BigEndianExplicitTransferSyntax;
+          transferSyntaxes[25] = UID_LittleEndianExplicitTransferSyntax;
+          transferSyntaxes[26] = UID_BigEndianExplicitTransferSyntax;
         } else {
-          transferSyntaxes[28] = UID_BigEndianExplicitTransferSyntax;
-          transferSyntaxes[29] = UID_LittleEndianExplicitTransferSyntax;
+          transferSyntaxes[25] = UID_BigEndianExplicitTransferSyntax;
+          transferSyntaxes[26] = UID_LittleEndianExplicitTransferSyntax;
         }
-        transferSyntaxes[30] = UID_LittleEndianImplicitTransferSyntax;
-        numTransferSyntaxes = 31;
+        transferSyntaxes[27] = UID_LittleEndianImplicitTransferSyntax;
+        numTransferSyntaxes = 28;
       } else {
         /* We prefer explicit transfer syntaxes.
          * If we are running on a Little Endian machine we prefer
@@ -1674,7 +1674,7 @@ static void mapCharacterAndAppendToString(Uint8 c,
 
 struct StoreCallbackData
 {
-  char* imageFileName;
+  const char* imageFileName;
   DcmFileFormat* dcmff;
   T_ASC_Association* assoc;
 };
@@ -2006,7 +2006,7 @@ static OFCondition storeSCP(
   // if opt_ignore is set, the user requires that the data shall be received but not
   // stored. in this case, we want to create a corresponding temporary filename for
   // a file in which the data shall be stored temporarily. If this is not the case,
-  // create a real filename (consisting of path and filename) for a real file.         
+  // create a real filename (consisting of path and filename) for a real file.
   if (opt_ignore)
   {
 #ifdef _WIN32
@@ -2017,7 +2017,7 @@ static OFCondition storeSCP(
   }
   else
   {
-    // 3 possibilities: create unique filenames (fn), create timestamp fn, create fn from SOP Instance UIDs           
+    // 3 possibilities: create unique filenames (fn), create timestamp fn, create fn from SOP Instance UIDs
     if (opt_uniqueFilenames)
     {
       // create unique filename by generating a temporary UID and using ".X." as an infix
@@ -2198,33 +2198,6 @@ static void executeEndOfStudyEvents()
   lastStudySubdirectoryPathAndName.clear();
 }
 
-/* replace all characters that might be interpreted by the shell with underscores
- */
-static void sanitizeAETitle(OFString& aet)
-{
-  static const char sanitized_aetitle_charset[] =
-  {
-    ' ', '_', '_', '_', '_', '_', '_', '_', '_', '_', '_', '_', '_', '-', '.', '_',
-    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', ':', '_', '_', '_', '_', '_',
-    '@', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O',
-    'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '_', '_', '_', '_', '_',
-    '_', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o',
-    'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '_', '_', '_', '_', '_'
-  };
-
-  // the aet string starts and ends with quotation marks. We ignore these.
-  size_t len = aet.length();
-  if (len < 3) return;
-
-  char c;
-  --len;
-  for (size_t i=1; i < len; ++i)
-  {
-    c = aet[i];
-    if (c != 0 && (c < 32 || c >= 127)) c = '_'; else c = sanitized_aetitle_charset[c-32];
-    aet[i] = c;
-  }
-}
 
 static void executeOnReception()
     /*
@@ -2241,7 +2214,6 @@ static void executeOnReception()
      */
 {
   OFString cmd = opt_execOnReception;
-  OFString s;
 
   // in case a file was actually written
   if( !opt_ignore )
@@ -2257,22 +2229,10 @@ static void executeOnReception()
   }
 
   // perform substitution for placeholder #a
-  s = callingAETitle;
-  sanitizeAETitle(s);
-  if (s != callingAETitle)
-  {
-    OFLOG_WARN(storescpLogger, "Sanitized unusual characters in calling aetitle, converted from " << callingAETitle << " to " << s << ".");
-  }
-  cmd = replaceChars( cmd, OFString(CALLING_AETITLE_PLACEHOLDER), s );
+  cmd = replaceChars( cmd, OFString(CALLING_AETITLE_PLACEHOLDER), callingAETitle );
 
   // perform substitution for placeholder #c
-  s = calledAETitle;
-  sanitizeAETitle(s);
-  if (s != calledAETitle)
-  {
-    OFLOG_WARN(storescpLogger, "Sanitized unusual characters in called aetitle, converted from " << calledAETitle << " to " << s << ".");
-  }
-  cmd = replaceChars( cmd, OFString(CALLED_AETITLE_PLACEHOLDER), s );
+  cmd = replaceChars( cmd, OFString(CALLED_AETITLE_PLACEHOLDER), calledAETitle );
 
   // perform substitution for placeholder #r
   cmd = replaceChars( cmd, OFString(CALLING_PRESENTATION_ADDRESS_PLACEHOLDER), callingPresentationAddress );
@@ -2377,20 +2337,15 @@ static void executeOnEndOfStudy()
      */
 {
   OFString cmd = opt_execOnEndOfStudy;
-  OFString s;
 
   // perform substitution for placeholder #p; #p will be substituted by lastStudySubdirectoryPathAndName
   cmd = replaceChars( cmd, OFString(PATH_PLACEHOLDER), lastStudySubdirectoryPathAndName );
 
   // perform substitution for placeholder #a
-  s = callingAETitle;
-  sanitizeAETitle(s);
-  cmd = replaceChars( cmd, OFString(CALLING_AETITLE_PLACEHOLDER), s );
+  cmd = replaceChars( cmd, OFString(CALLING_AETITLE_PLACEHOLDER), callingAETitle );
 
   // perform substitution for placeholder #c
-  s = calledAETitle;
-  sanitizeAETitle(s);
-  cmd = replaceChars( cmd, OFString(CALLED_AETITLE_PLACEHOLDER), s );
+  cmd = replaceChars( cmd, OFString(CALLED_AETITLE_PLACEHOLDER), calledAETitle );
 
   // perform substitution for placeholder #r
   cmd = replaceChars( cmd, OFString(CALLING_PRESENTATION_ADDRESS_PLACEHOLDER), callingPresentationAddress );
@@ -2488,6 +2443,8 @@ static void executeCommand( const OFString &cmd )
 
 #ifdef HAVE_WAITPID
 static void cleanChildren(pid_t pid, OFBool synch)
+#elif defined(HAVE_WAIT3)
+static void cleanChildren(pid_t /* pid */, OFBool synch)
 #else
 static void cleanChildren(pid_t /* pid */, OFBool /* synch */)
 #endif
@@ -2498,11 +2455,26 @@ static void cleanChildren(pid_t /* pid */, OFBool /* synch */)
 {
 #ifdef HAVE_WAITPID
   int stat_loc;
+#elif defined(HAVE_WAIT3)
+  struct rusage rusage;
+#if defined(__NeXT__)
+  /* some systems need a union wait as argument to wait3 */
+  union wait status;
+#else
+  int        status;
+#endif
+#endif
+
+#if defined(HAVE_WAITPID) || defined(HAVE_WAIT3)
   int child = 1;
   int options = synch ? 0 : WNOHANG;
   while (child > 0)
   {
+#ifdef HAVE_WAITPID
     child = OFstatic_cast(int, waitpid(pid, &stat_loc, options));
+#elif defined(HAVE_WAIT3)
+    child = wait3(&status, options, &rusage);
+#endif
     if (child < 0)
     {
       if (errno != ECHILD)


### PR DESCRIPTION
Simplest attempt at correcting issue #1122.
When movescu is called with +B (--bit-preserving) option, the output file ends up in the current working directory as opposed to the desired output directory even if you add the -od (--output-directory) option in the command line.

Note that a better approach could be to have a singular writing function and adjust the function signatures to pass whether other processing logic should be skipped. However, that could cause a lot of headaches ensuring all logic paths are checked against the current bit-preserving behavior of outputting the data as-is.

I leave the option to the maintainer if to request further work to address this issue more comprehensively or if the change proposed here is good enough for the project.

The changes here work as intended in my test environment.

https://support.dcmtk.org/redmine/issues/1122