### PR TITLE
IPV6  Unknown host error

### DIFF
--- a/dcmnet/libsrc/dulfsm.cc
+++ b/dcmnet/libsrc/dulfsm.cc
@@ -2255,8 +2255,22 @@ requestAssociationTCP(PRIVATE_NETWORKKEY ** network,
     int s;
 #endif
     struct linger sockarg;
-
-    if (sscanf(params->calledPresentationAddress, "%[^:]:%d", node, &port) != 2)
+	
+    // ipv6 address was not parsing properly, so corrected the below code.
+    // convert the char array to a std::string
+    std::string addressString(params->calledPresentationAddress);
+    // find the last colon in the string to split the node and port
+    size_t lastColonPos = addressString.find_last_of(':');
+    if (lastColonPos != std::string::npos) {
+        // extract node and port from the string
+        std::string nodeStr = addressString.substr(0, lastColonPos);
+        std::string portStr = addressString.substr(lastColonPos + 1);
+        // copy node string into node char array
+        strncpy_s(node, sizeof(node), nodeStr.c_str(), _TRUNCATE);
+        // convert port string to integer
+        port = std::stoi(portStr);
+    }
+    else
     {
         char buf[1024];
         OFStandard::snprintf(buf, sizeof(buf), "Illegal service parameter: %s", params->calledPresentationAddress);

--- a/ofstd/libsrc/ofstd.cc
+++ b/ofstd/libsrc/ofstd.cc
@@ -2905,11 +2905,10 @@ void OFStandard::getAddressByHostname(const char *name, OFSockAddr& result)
   struct addrinfo *result_list = NULL;
   int err = EAI_AGAIN;
   int rep = DCMTK_MAX_EAI_AGAIN_REPETITIONS;
-
-  // filter for the DNS lookup. Since DCMTK does not yet fully support IPv6,
-  // we only look for IPv4 addresses.
+  
   ::addrinfo hint = {};
-  hint.ai_family = AF_INET;
+  // in order to support IPV6 address too in  DNS lookup we are changing ai_family to AF_UNSPEC.
+  hint.ai_family = AF_UNSPEC;
 
   // perform DNS lookup. Repeat while we receive temporary failures.
   while ((EAI_AGAIN == err) && (rep-- > 0)) err = getaddrinfo(name, NULL, &hint, &result_list);


### PR DESCRIPTION
Fixed IPV6 address association failures in requestAssociationTCP() function of dulfsm.cc. 
Reference https://forum.dcmtk.org/viewtopic.php?t=5373 

The issue was due to getaddrinfo() not checking IPV6 addresses for DNS lookup, resulting in an ‘Attempt to connect to unknown host’ error.  Additionally, corrected sscanf formatting issue for calledPresentationAddress when an IP6 address is passed.