### PR TITLE
Resolve ambiguous VR taken from dictionary

### DIFF
--- a/dcmdata/libsrc/dcitem.cc
+++ b/dcmdata/libsrc/dcitem.cc
@@ -1098,6 +1098,9 @@ OFCondition DcmItem::readTagAndLength(DcmInputStream &inStream,
         /* the VR in the dataset might be wrong, so the user can decide to ignore it */
         if (dcmPreferVRFromDataDictionary.get() && (newEVR != EVR_UNKNOWN) && (newEVR != EVR_UNKNOWN2B))
         {
+            /* resolve ambiguous VRs */
+            checkAndUpdateVR(*this, newTag);
+            newEVR = newTag.getEVR();
             if (newEVR != vr.getEVR())
             {
                 /* ignore explicit VR in dataset if tag is defined in data dictionary */

--- a/dcmdata/tests/tests.cc
+++ b/dcmdata/tests/tests.cc
@@ -97,6 +97,7 @@ OFTEST_REGISTER(dcmdata_sequenceInsert);
 OFTEST_REGISTER(dcmdata_pixelSequenceInsert);
 OFTEST_REGISTER(dcmdata_findAndGetSequenceItem);
 OFTEST_REGISTER(dcmdata_findAndGetUint16Array);
+OFTEST_REGISTER(dcmdata_handleAmbiguousVR_fromDictionary);
 OFTEST_REGISTER(dcmdata_parser_missingDelimitationItems);
 OFTEST_REGISTER(dcmdata_parser_missingSequenceDelimitationItem_1);
 OFTEST_REGISTER(dcmdata_parser_missingSequenceDelimitationItem_2);

--- a/dcmdata/tests/titem.cc
+++ b/dcmdata/tests/titem.cc
@@ -28,6 +28,11 @@
 #include "dcmtk/dcmdata/dcvrus.h"
 #include "dcmtk/dcmdata/dcdeftag.h"
 
+#include "dctmacro.h"
+
+#define ENDIAN_UINT16(w) LITTLE_ENDIAN_UINT16(w)
+#define ENDIAN_UINT32(w) LITTLE_ENDIAN_UINT32(w)
+
 
 OFTEST(dcmdata_findAndGetUint16Array)
 {
@@ -47,4 +52,25 @@ OFTEST(dcmdata_findAndGetUint16Array)
     OFCHECK_EQUAL(numUints, 2);
     OFCHECK(item.findAndGetUint16Array(DCM_FrameIncrementPointer, uintVals, &numUints).good());
     OFCHECK_EQUAL(numUints, 2);
+}
+
+
+OFTEST(dcmdata_handleAmbiguousVR_fromDictionary)
+{
+    /* enable setting VR from data dictionary */
+    dcmPreferVRFromDataDictionary.set(true);
+    /* create wave data for OW */
+    const Uint8 data[] = {
+        TAG_AND_LENGTH_SHORT(DCM_WaveformBitsAllocated, 'U', 'S', 2),
+        '\x00', '\x10',
+        TAG_AND_LENGTH(DCM_WaveformData, 'O', 'W', 8),
+        '\x00', '\x01', '\x00', '\x02', '\x00', '\x03', '\x00', '\x04',
+    };
+    DcmDataset dset;
+    OFCHECK(readDataset(dset, data, sizeof data, EXS_LittleEndianExplicit).good());
+    const Uint16 *uintVals = nullptr;
+    unsigned long numUints = 0;
+    /* check that the data can be accessed as a 16-bit array (regression test, used to fail with EC_IllegalCall) */
+    OFCHECK(dset.getRootItem()->findAndGetUint16Array(DCM_WaveformData, uintVals, &numUints).good());
+    OFCHECK_EQUAL(numUints, 4);
 }


### PR DESCRIPTION
- with dcmPreferVRFromDataDictionary set, the VR is reset to the dictionary VR, which may be ambiguous (e.g. EVR_ox, EVR_px...); in this case, the VR has to be resolved