### PR TITLE
Reduce log level in readUntilTag

### DIFF
--- a/dcmdata/libsrc/dcitem.cc
+++ b/dcmdata/libsrc/dcitem.cc
@@ -1447,7 +1447,7 @@ OFCondition DcmItem::readUntilTag(DcmInputStream & inStream,
                     {
                       lastElementComplete = OFTrue;
                       readStopElem = OFTrue;
-                      DCMDATA_INFO("DcmItem: Element " << newTag.getTagName() << " " << newTag
+                      DCMDATA_DEBUG("DcmItem: Element " << newTag.getTagName() << " " << newTag
                         << " encountered, skipping rest of dataset");
                     }
                     else


### PR DESCRIPTION
No need to repeat at information level what the programmer has setup.