### PR TITLE
Fixed ofstd build error in debug mode with C++20.

### DIFF
--- a/ofstd/libsrc/ofcmdln.cc
+++ b/ofstd/libsrc/ofcmdln.cc
@@ -1243,7 +1243,7 @@ OFCommandLine::E_ParseStatus OFCommandLine::parseCommandFile(const wchar_t *argV
 #ifdef DEBUG
             if (block != 0)
             {
-                ofConsole.lockCerr() << "WARNING: closing quotation mark (" << block << ") missing in command file " << strValue << OFendl;
+                ofConsole.lockCerr() << "WARNING: closing quotation mark (" << (unsigned)block << ") missing in command file " << strValue << OFendl;
                 ofConsole.unlockCerr();
             }
 #endif


### PR DESCRIPTION
Found an issue when building ofstd in debug mode with c++20.
![image](https://github.com/DCMTK/dcmtk/assets/89074160/db6e225a-80b3-47b3-97be-32c31a915b1b)
