### PR TITLE
Fix single shared library build error in Linux

### DIFF
--- a/dcmjpeg/libijg12/jaricom.c
+++ b/dcmjpeg/libijg12/jaricom.c
@@ -12,4 +12,4 @@
 #include "jinclude12.h"
 #include "jpeglib12.h"
 
-IJG_INT32 jaritab[1];	/* dummy table */
+extern IJG_INT32 jaritab[1];	/* dummy table */

--- a/dcmjpeg/libijg16/jaricom.c
+++ b/dcmjpeg/libijg16/jaricom.c
@@ -12,4 +12,4 @@
 #include "jinclude16.h"
 #include "jpeglib16.h"
 
-IJG_INT32 jaritab[1];	/* dummy table */
+extern IJG_INT32 jaritab[1];	/* dummy table */

--- a/dcmjpeg/libijg8/jaricom.c
+++ b/dcmjpeg/libijg8/jaricom.c
@@ -12,4 +12,4 @@
 #include "jinclude8.h"
 #include "jpeglib8.h"
 
-IJG_INT32 jaritab[1];	/* dummy table */
+extern IJG_INT32 jaritab[1];	/* dummy table */


### PR DESCRIPTION
I encountered an error while building a single shared library on Linux (Ubuntu 24.04 LTS, GCC 13.2.0, CMake 3.30.0)
![Screenshot from 2024-07-19 00-47-57](https://github.com/user-attachments/assets/346af79b-5d7b-4835-a16c-e30aa32620f3)
