### PR TITLE
Fix negative array access on EXS_Unknown

### DIFF
--- a/dcmdata/libsrc/dcxfer.cc
+++ b/dcmdata/libsrc/dcxfer.cc
@@ -854,7 +854,7 @@ DcmXfer::DcmXfer(E_TransferSyntax xfer)
     /* casting the enum to an integer should be safe */
     const int i = OFstatic_cast(int, xfer);
     /* ... but you never know, so double-check this */
-    if ((i < DIM_OF_XferNames) && (XferNames[i].xfer == xfer))
+    if ((0 <= i) && (i < DIM_OF_XferNames) && (XferNames[i].xfer == xfer))
     {
         xferSyn               = XferNames[i].xfer;
         xferID                = XferNames[i].xferID;


### PR DESCRIPTION
When a `DcmXfer` is initialized with `EXS_Unknown` (which does happen), a negative array access happens on `XferNames`.

The existing `XferNames[i].xfer == xfer` check prevents anything too wild from happening, unless a build is super unlucky about what appears before `XferNames` in global memory. But, better not to rely on that.