### PR TITLE
ENH: Replace HTML_HYPERLINK_PREFIX_FOR_CGI with std::string argument

### DIFF
--- a/dcmsr/include/dcmtk/dcmsr/dsrcomtn.h
+++ b/dcmsr/include/dcmtk/dcmsr/dsrcomtn.h
@@ -157,6 +157,7 @@ class DCMTK_DCMSR_EXPORT DSRCompositeTreeNode
                                               STD_NAMESPACE ostream &annexStream,
                                               const size_t nestingLevel,
                                               size_t &annexNumber,
+                                              const std::string& urlPrefixToCompositeObjects,
                                               const size_t flags) const;
 
 

--- a/dcmsr/include/dcmtk/dcmsr/dsrcomvl.h
+++ b/dcmsr/include/dcmtk/dcmsr/dsrcomvl.h
@@ -176,6 +176,7 @@ class DCMTK_DCMSR_EXPORT DSRCompositeReferenceValue
     virtual OFCondition renderHTML(STD_NAMESPACE ostream &docStream,
                                    STD_NAMESPACE ostream &annexStream,
                                    size_t &annexNumber,
+                                   const std::string& urlPrefixToCompositeObjects,
                                    const size_t flags) const;
 
     /** get SOP class UID

--- a/dcmsr/include/dcmtk/dcmsr/dsrcontn.h
+++ b/dcmsr/include/dcmtk/dcmsr/dsrcontn.h
@@ -143,6 +143,7 @@ class DCMTK_DCMSR_EXPORT DSRContainerTreeNode
                                    STD_NAMESPACE ostream &annexStream,
                                    const size_t nestingLevel,
                                    size_t &annexNumber,
+                                   const std::string& urlPrefixToCompositeObjects,
                                    const size_t flags) const;
 
     /** get continuity of content flag.

--- a/dcmsr/include/dcmtk/dcmsr/dsrdoc.h
+++ b/dcmsr/include/dcmtk/dcmsr/dsrdoc.h
@@ -26,6 +26,7 @@
 
 #include "dcmtk/config/osconfig.h"   /* make sure OS specific configuration is included first */
 
+#include "dcmtk/dcmsr/dsrtypes.h"
 #include "dcmtk/dcmsr/dsrdoctr.h"
 #include "dcmtk/dcmsr/dsrrtpl.h"
 #include "dcmtk/dcmsr/dsrsoprf.h"
@@ -200,7 +201,9 @@ class DCMTK_DCMSR_EXPORT DSRDocument
      */
     virtual OFCondition renderHTML(STD_NAMESPACE ostream &stream,
                                    const size_t flags = 0,
-                                   const char *styleSheet = NULL);
+                                   const char* styleSheet = NULL,
+                                   const std::string& urlPrefixToCompositeObjects = HTML_HYPERLINK_PREFIX_FOR_CGI
+        );
 
 
   // --- get/set misc attributes ---
@@ -1281,6 +1284,7 @@ class DCMTK_DCMSR_EXPORT DSRDocument
      */
     void renderHTMLReferenceList(STD_NAMESPACE ostream &stream,
                                  DSRSOPInstanceReferenceList &refList,
+                                 const std::string& urlPrefixToCompositeObjects,
                                  const size_t flags);
 
     /** render list of referenced SOP instances in HTML/XHTML format
@@ -1290,6 +1294,7 @@ class DCMTK_DCMSR_EXPORT DSRDocument
      */
     void renderHTMLReferenceList(STD_NAMESPACE ostream &stream,
                                  DSRReferencedInstanceList &refList,
+                                 const std::string& urlPrefixToCompositeObjects,
                                  const size_t flags);
 
     /** check the given dataset before reading.

--- a/dcmsr/include/dcmtk/dcmsr/dsrdoctn.h
+++ b/dcmsr/include/dcmtk/dcmsr/dsrdoctn.h
@@ -223,6 +223,7 @@ class DCMTK_DCMSR_EXPORT DSRDocumentTreeNode
                                    STD_NAMESPACE ostream &annexStream,
                                    const size_t nestingLevel,
                                    size_t &annexNumber,
+                                   const std::string& urlPrefixToCompositeObjects,
                                    const size_t flags) const;
 
     /** check whether content item is digitally signed.
@@ -593,6 +594,7 @@ class DCMTK_DCMSR_EXPORT DSRDocumentTreeNode
                                               STD_NAMESPACE ostream &annexStream,
                                               const size_t nestingLevel,
                                               size_t &annexNumber,
+                                              const std::string& urlPrefixToCompositeObjects,
                                               const size_t flags) const;
 
     /** write common item start (XML tag)
@@ -711,6 +713,7 @@ class DCMTK_DCMSR_EXPORT DSRDocumentTreeNode
                                      STD_NAMESPACE ostream &annexStream,
                                      const size_t nestingLevel,
                                      size_t &annexNumber,
+                                     const std::string& urlPrefixToCompositeObjects,
                                      const size_t flags) const;
 
   // --- static function ---

--- a/dcmsr/include/dcmtk/dcmsr/dsrdoctr.h
+++ b/dcmsr/include/dcmtk/dcmsr/dsrdoctr.h
@@ -141,6 +141,7 @@ class DCMTK_DCMSR_EXPORT DSRDocumentTree
      */
     virtual OFCondition renderHTML(STD_NAMESPACE ostream &docStream,
                                    STD_NAMESPACE ostream &annexStream,
+                                   const std::string& urlPrefixToCompositeObjects,
                                    const size_t flags = 0);
 
     /** get document type

--- a/dcmsr/include/dcmtk/dcmsr/dsrimgtn.h
+++ b/dcmsr/include/dcmtk/dcmsr/dsrimgtn.h
@@ -168,6 +168,7 @@ class DCMTK_DCMSR_EXPORT DSRImageTreeNode
                                               STD_NAMESPACE ostream &annexStream,
                                               const size_t nestingLevel,
                                               size_t &annexNumber,
+                                              const std::string& urlPrefixToCompositeObjects,
                                               const size_t flags) const;
 
 

--- a/dcmsr/include/dcmtk/dcmsr/dsrimgvl.h
+++ b/dcmsr/include/dcmtk/dcmsr/dsrimgvl.h
@@ -198,6 +198,7 @@ class DCMTK_DCMSR_EXPORT DSRImageReferenceValue
     virtual OFCondition renderHTML(STD_NAMESPACE ostream &docStream,
                                    STD_NAMESPACE ostream &annexStream,
                                    size_t &annexNumber,
+                                   const std::string& urlPrefixToCompositeObjects,
                                    const size_t flags) const;
 
     /** create an icon image from the given DICOM image and associate it with this image

--- a/dcmsr/include/dcmtk/dcmsr/dsrwavtn.h
+++ b/dcmsr/include/dcmtk/dcmsr/dsrwavtn.h
@@ -165,6 +165,7 @@ class DCMTK_DCMSR_EXPORT DSRWaveformTreeNode
                                               STD_NAMESPACE ostream &annexStream,
                                               const size_t nestingLevel,
                                               size_t &annexNumber,
+                                              const std::string& urlPrefixToCompositeObjects,
                                               const size_t flags) const;
 
 

--- a/dcmsr/include/dcmtk/dcmsr/dsrwavvl.h
+++ b/dcmsr/include/dcmtk/dcmsr/dsrwavvl.h
@@ -142,6 +142,7 @@ class DCMTK_DCMSR_EXPORT DSRWaveformReferenceValue
     virtual OFCondition renderHTML(STD_NAMESPACE ostream &docStream,
                                    STD_NAMESPACE ostream &annexStream,
                                    size_t &annexNumber,
+                                   const std::string& urlPrefixToCompositeObjects,
                                    const size_t flags) const;
 
     /** get reference to waveform reference value

--- a/dcmsr/libsrc/dsrcomtn.cc
+++ b/dcmsr/libsrc/dsrcomtn.cc
@@ -158,6 +158,7 @@ OFCondition DSRCompositeTreeNode::renderHTMLContentItem(STD_NAMESPACE ostream &d
                                                         STD_NAMESPACE ostream &annexStream,
                                                         const size_t /* nestingLevel */,
                                                         size_t &annexNumber,
+                                                        const std::string& urlPrefixToCompositeObjects,
                                                         const size_t flags) const
 {
     /* render ConceptName */
@@ -165,7 +166,7 @@ OFCondition DSRCompositeTreeNode::renderHTMLContentItem(STD_NAMESPACE ostream &d
     /* render Reference */
     if (result.good())
     {
-        result = DSRCompositeReferenceValue::renderHTML(docStream, annexStream, annexNumber, flags);
+        result = DSRCompositeReferenceValue::renderHTML(docStream, annexStream, annexNumber, urlPrefixToCompositeObjects, flags);
         docStream << OFendl;
     }
     return result;

--- a/dcmsr/libsrc/dsrcomvl.cc
+++ b/dcmsr/libsrc/dsrcomvl.cc
@@ -244,10 +244,11 @@ OFCondition DSRCompositeReferenceValue::writeSequence(DcmItem &dataset,
 OFCondition DSRCompositeReferenceValue::renderHTML(STD_NAMESPACE ostream &docStream,
                                                    STD_NAMESPACE ostream & /*annexStream*/,
                                                    size_t & /*annexNumber*/,
+                                                   const std::string& urlPrefixToCompositeObjects,
                                                    const size_t /*flags*/) const
 {
     /* render reference */
-    docStream << "<a href=\"" << HTML_HYPERLINK_PREFIX_FOR_CGI;
+    docStream << "<a href=\"" << urlPrefixToCompositeObjects;
     docStream << "?composite=" << SOPClassUID << "+" << SOPInstanceUID << "\">";
     /* retrieve name of SOP class (if known) */
     docStream << dcmFindNameOfUID(SOPClassUID.c_str(), "unknown composite object");

--- a/dcmsr/libsrc/dsrcontn.cc
+++ b/dcmsr/libsrc/dsrcontn.cc
@@ -226,6 +226,7 @@ OFCondition DSRContainerTreeNode::renderHTML(STD_NAMESPACE ostream &docStream,
                                              STD_NAMESPACE ostream &annexStream,
                                              const size_t nestingLevel,
                                              size_t &annexNumber,
+                                             const std::string& urlPrefixToCompositeObjects,
                                              const size_t flags) const
 {
     /* check for validity */
@@ -237,9 +238,9 @@ OFCondition DSRContainerTreeNode::renderHTML(STD_NAMESPACE ostream &docStream,
     {
         /* section body: render child nodes */
         if (ContinuityOfContent == COC_Continuous)
-            result = renderHTMLChildNodes(docStream, annexStream, nestingLevel, annexNumber, flags & ~HF_renderItemsSeparately);
+            result = renderHTMLChildNodes(docStream, annexStream, nestingLevel, annexNumber, urlPrefixToCompositeObjects, flags & ~HF_renderItemsSeparately);
         else  // might be invalid
-            result = renderHTMLChildNodes(docStream, annexStream, nestingLevel, annexNumber, flags | HF_renderItemsSeparately);
+            result = renderHTMLChildNodes(docStream, annexStream, nestingLevel, annexNumber, urlPrefixToCompositeObjects, flags | HF_renderItemsSeparately);
     } else
         printContentItemErrorMessage("Rendering", result, this);
     return result;

--- a/dcmsr/libsrc/dsrdoc.cc
+++ b/dcmsr/libsrc/dsrdoc.cc
@@ -1569,6 +1569,7 @@ void DSRDocument::renderHTMLPatientData(STD_NAMESPACE ostream &stream,
 
 void DSRDocument::renderHTMLReferenceList(STD_NAMESPACE ostream &stream,
                                           DSRSOPInstanceReferenceList &refList,
+                                          const std::string& urlPrefixToCompositeObjects,
                                           const size_t flags)
 {
     /* goto first list item (if not empty) */
@@ -1589,7 +1590,7 @@ void DSRDocument::renderHTMLReferenceList(STD_NAMESPACE ostream &stream,
             OFString sopClass, sopInstance;
             if (!refList.getSOPClassUID(sopClass).empty() && !refList.getSOPInstanceUID(sopInstance).empty())
             {
-                stream << "<td><a href=\"" << HTML_HYPERLINK_PREFIX_FOR_CGI;
+                stream << "<td><a href=\"" << urlPrefixToCompositeObjects;
                 stream << "?composite=" << sopClass << "+" << sopInstance << "\">";
                 /* check whether referenced object has a well-known SOP class */
                 stream << dcmFindNameOfUID(sopClass.c_str(), "unknown composite object");
@@ -1608,6 +1609,7 @@ void DSRDocument::renderHTMLReferenceList(STD_NAMESPACE ostream &stream,
 
 void DSRDocument::renderHTMLReferenceList(STD_NAMESPACE ostream &stream,
                                           DSRReferencedInstanceList &refList,
+                                          const std::string& urlPrefixToCompositeObjects,
                                           const size_t flags)
 {
     /* goto first list item (if not empty) */
@@ -1628,7 +1630,7 @@ void DSRDocument::renderHTMLReferenceList(STD_NAMESPACE ostream &stream,
             OFString sopClass, sopInstance;
             if (!refList.getSOPClassUID(sopClass).empty() && !refList.getSOPInstanceUID(sopInstance).empty())
             {
-                stream << "<td><a href=\"" << HTML_HYPERLINK_PREFIX_FOR_CGI;
+                stream << "<td><a href=\"" << urlPrefixToCompositeObjects;
                 stream << "?composite=" << sopClass << "+" << sopInstance << "\">";
                 /* retrieve name of SOP class (if known) */
                 stream << dcmFindNameOfUID(sopClass.c_str(), "unknown composite object");
@@ -1647,9 +1649,12 @@ void DSRDocument::renderHTMLReferenceList(STD_NAMESPACE ostream &stream,
 
 OFCondition DSRDocument::renderHTML(STD_NAMESPACE ostream &stream,
                                     const size_t flags,
-                                    const char *styleSheet)
+                                    const char *styleSheet,
+                                    const std::string& urlPrefixToCompositeObjects
+    )
 {
     OFCondition result = SR_EC_InvalidDocument;
+
     /* only render valid documents */
     if (isValid())
     {
@@ -1874,7 +1879,7 @@ OFCondition DSRDocument::renderHTML(STD_NAMESPACE ostream &stream,
                 {
                     stream << "<tr>" << OFendl;
                     stream << "<td><b>Predecessor Docs:</b></td>" << OFendl;
-                    renderHTMLReferenceList(stream, PredecessorDocuments, flags);
+                    renderHTMLReferenceList(stream, PredecessorDocuments, urlPrefixToCompositeObjects, flags);
                     stream << "</tr>" << OFendl;
                 }
             }
@@ -1883,7 +1888,7 @@ OFCondition DSRDocument::renderHTML(STD_NAMESPACE ostream &stream,
             {
                 stream << "<tr>" << OFendl;
                 stream << "<td><b>Identical Docs:</b></td>" << OFendl;
-                renderHTMLReferenceList(stream, IdenticalDocuments, flags);
+                renderHTMLReferenceList(stream, IdenticalDocuments, urlPrefixToCompositeObjects, flags);
                 stream << "</tr>" << OFendl;
             }
             /* referenced instances */
@@ -1891,7 +1896,7 @@ OFCondition DSRDocument::renderHTML(STD_NAMESPACE ostream &stream,
             {
                 stream << "<tr>" << OFendl;
                 stream << "<td><b>Referenced Objects:</b></td>" << OFendl;
-                renderHTMLReferenceList(stream, ReferencedInstances, flags);
+                renderHTMLReferenceList(stream, ReferencedInstances, urlPrefixToCompositeObjects, flags);
                 stream << "</tr>" << OFendl;
             }
             if (usesGeneralSRModules)
@@ -1972,7 +1977,7 @@ OFCondition DSRDocument::renderHTML(STD_NAMESPACE ostream &stream,
         /* create memory output stream for the annex */
         OFOStringStream annexStream;
         /* render document tree two the streams */
-        result = DocumentTree.renderHTML(stream, annexStream, newFlags);
+        result = DocumentTree.renderHTML(stream, annexStream, urlPrefixToCompositeObjects, newFlags);
         /* append annex (with heading) to main document */
         if (result.good())
             result = appendStream(stream, annexStream, "<h1>Annex</h1>");

--- a/dcmsr/libsrc/dsrdoctn.cc
+++ b/dcmsr/libsrc/dsrdoctn.cc
@@ -453,6 +453,7 @@ OFCondition DSRDocumentTreeNode::renderHTML(STD_NAMESPACE ostream &docStream,
                                             STD_NAMESPACE ostream &annexStream,
                                             const size_t nestingLevel,
                                             size_t &annexNumber,
+                                            const std::string& urlPrefixToCompositeObjects,
                                             const size_t flags) const
 {
     /* check for validity */
@@ -466,10 +467,10 @@ OFCondition DSRDocumentTreeNode::renderHTML(STD_NAMESPACE ostream &docStream,
         docStream << "<a " << attrName << "=\"content_item_" << getNodeID() << "\"" << closeElm << ">" << OFendl;
     }
     /* render content item */
-    OFCondition result = renderHTMLContentItem(docStream, annexStream, nestingLevel, annexNumber, flags);
+    OFCondition result = renderHTMLContentItem(docStream, annexStream, nestingLevel, annexNumber, urlPrefixToCompositeObjects, flags);
     /* render child nodes */
     if (result.good())
-        result = renderHTMLChildNodes(docStream, annexStream, nestingLevel, annexNumber, flags | HF_renderItemsSeparately);
+        result = renderHTMLChildNodes(docStream, annexStream, nestingLevel, annexNumber, urlPrefixToCompositeObjects, flags | HF_renderItemsSeparately);
     else
         printContentItemErrorMessage("Rendering", result, this);
     return result;
@@ -667,6 +668,7 @@ OFCondition DSRDocumentTreeNode::renderHTMLContentItem(STD_NAMESPACE ostream & /
                                                        STD_NAMESPACE ostream & /*annexStream*/,
                                                        const size_t /*nestingLevel*/,
                                                        size_t & /*annexNumber*/,
+                                                       const std::string& /*urlPrefixToCompositeObjects*/,
                                                        const size_t /*flags*/) const
 {
     /* no content to render */
@@ -1169,6 +1171,7 @@ OFCondition DSRDocumentTreeNode::renderHTMLChildNodes(STD_NAMESPACE ostream &doc
                                                       STD_NAMESPACE ostream &annexStream,
                                                       const size_t nestingLevel,
                                                       size_t &annexNumber,
+                                                      const std::string& urlPrefixToCompositeObjects,
                                                       const size_t flags) const
 {
     OFCondition result = EC_Normal;
@@ -1235,7 +1238,7 @@ OFCondition DSRDocumentTreeNode::renderHTMLChildNodes(STD_NAMESPACE ostream &doc
                         docStream << " = ";
                     }
                     /* render HTML code (directly to the reference text) */
-                    result = node->renderHTML(docStream, annexStream, 0 /*nesting level*/, annexNumber, newFlags | HF_renderItemInline);
+                    result = node->renderHTML(docStream, annexStream, 0 /*nesting level*/, annexNumber, urlPrefixToCompositeObjects, newFlags | HF_renderItemInline);
                 } else {
                     /* render concept name or value type */
                     if (node->getConceptName().getCodeMeaning().empty())
@@ -1251,7 +1254,7 @@ OFCondition DSRDocumentTreeNode::renderHTMLChildNodes(STD_NAMESPACE ostream &doc
                     /* create memory output stream for the temporal annex */
                     OFOStringStream tempAnnexStream;
                     /* render HTML code (directly to the annex) */
-                    result = node->renderHTML(annexStream, tempAnnexStream, 0 /*nesting level*/, annexNumber, newFlags | HF_currentlyInsideAnnex);
+                    result = node->renderHTML(annexStream, tempAnnexStream, 0 /*nesting level*/, annexNumber, urlPrefixToCompositeObjects, newFlags | HF_currentlyInsideAnnex);
                     annexStream << "</div>" << OFendl;
                     /* use empty paragraph for bottom margin */
                     if (!(flags & HF_XHTML11Compatibility))
@@ -1286,7 +1289,7 @@ OFCondition DSRDocumentTreeNode::renderHTMLChildNodes(STD_NAMESPACE ostream &doc
                 if (newFlags & HF_createFootnoteReferences)
                 {
                     /* render HTML code (without child nodes) */
-                    result = node->renderHTMLContentItem(docStream, annexStream, 0 /*nestingLevel*/, annexNumber, newFlags);
+                    result = node->renderHTMLContentItem(docStream, annexStream, 0 /*nestingLevel*/, annexNumber, urlPrefixToCompositeObjects, newFlags);
                     /* create footnote numbers (individually for each child?) */
                     if (result.good())
                     {
@@ -1302,11 +1305,11 @@ OFCondition DSRDocumentTreeNode::renderHTMLChildNodes(STD_NAMESPACE ostream &doc
                         /* render footnote text and reference */
                         createHTMLFootnote(docStream, tempDocStream, footnoteNumber, node->getNodeID(), flags);
                         /* render child nodes to temporary stream */
-                        result = node->renderHTMLChildNodes(tempDocStream, annexStream, 0 /*nestingLevel*/, annexNumber, newFlags);
+                        result = node->renderHTMLChildNodes(tempDocStream, annexStream, 0 /*nestingLevel*/, annexNumber, urlPrefixToCompositeObjects, newFlags);
                     }
                 } else {
                     /* render HTML code (incl. child nodes)*/
-                    result = node->renderHTML(docStream, annexStream, nestingLevel + 1, annexNumber, newFlags);
+                    result = node->renderHTML(docStream, annexStream, nestingLevel + 1, annexNumber, urlPrefixToCompositeObjects, newFlags);
                 }
                 /* end paragraph */
                 if (flags & HF_renderItemsSeparately)

--- a/dcmsr/libsrc/dsrdoctr.cc
+++ b/dcmsr/libsrc/dsrdoctr.cc
@@ -244,6 +244,7 @@ OFCondition DSRDocumentTree::readXML(const DSRXMLDocument &doc,
 
 OFCondition DSRDocumentTree::renderHTML(STD_NAMESPACE ostream &docStream,
                                         STD_NAMESPACE ostream &annexStream,
+                                        const std::string& urlPrefixToCompositeObjects,
                                         const size_t flags)
 {
     OFCondition result = SR_EC_InvalidDocumentTree;
@@ -262,7 +263,7 @@ OFCondition DSRDocumentTree::renderHTML(STD_NAMESPACE ostream &docStream,
                 /* update the document tree for output (if needed) */
                 updateTreeForOutput();
                 /* start rendering from root node */
-                result = node->renderHTML(docStream, annexStream, 1 /*nestingLevel*/, annexNumber, flags & ~HF_internalUseOnly);
+                result = node->renderHTML(docStream, annexStream, 1 /*nestingLevel*/, annexNumber, urlPrefixToCompositeObjects, flags & ~HF_internalUseOnly);
             }
         } else {
             /* tbd: cannot render document with included templates */

--- a/dcmsr/libsrc/dsrimgtn.cc
+++ b/dcmsr/libsrc/dsrimgtn.cc
@@ -163,6 +163,7 @@ OFCondition DSRImageTreeNode::renderHTMLContentItem(STD_NAMESPACE ostream &docSt
                                                     STD_NAMESPACE ostream &annexStream,
                                                     const size_t /*nestingLevel*/,
                                                     size_t &annexNumber,
+                                                    const std::string& urlPrefixToCompositeObjects,
                                                     const size_t flags) const
 {
     /* render ConceptName */
@@ -170,7 +171,7 @@ OFCondition DSRImageTreeNode::renderHTMLContentItem(STD_NAMESPACE ostream &docSt
     /* render Reference */
     if (result.good())
     {
-        result = DSRImageReferenceValue::renderHTML(docStream, annexStream, annexNumber, flags);
+        result = DSRImageReferenceValue::renderHTML(docStream, annexStream, annexNumber, urlPrefixToCompositeObjects, flags);
         docStream << OFendl;
     }
     return result;

--- a/dcmsr/libsrc/dsrimgvl.cc
+++ b/dcmsr/libsrc/dsrimgvl.cc
@@ -441,10 +441,11 @@ OFCondition DSRImageReferenceValue::writeItem(DcmItem &dataset) const
 OFCondition DSRImageReferenceValue::renderHTML(STD_NAMESPACE ostream &docStream,
                                                STD_NAMESPACE ostream &annexStream,
                                                size_t &annexNumber,
+                                               const std::string& urlPrefixToCompositeObjects,
                                                const size_t flags) const
 {
     /* reference: image */
-    docStream << "<a href=\"" << HTML_HYPERLINK_PREFIX_FOR_CGI;
+    docStream << "<a href=\"" << urlPrefixToCompositeObjects;
     docStream << "?image=" << SOPClassUID << "+" << SOPInstanceUID;
     /* reference: pstate */
     if (PresentationState.isValid())

--- a/dcmsr/libsrc/dsrwavtn.cc
+++ b/dcmsr/libsrc/dsrwavtn.cc
@@ -163,6 +163,7 @@ OFCondition DSRWaveformTreeNode::renderHTMLContentItem(STD_NAMESPACE ostream &do
                                                        STD_NAMESPACE ostream &annexStream,
                                                        const size_t /*nestingLevel*/,
                                                        size_t &annexNumber,
+                                                       const std::string& urlPrefixToCompositeObjects,
                                                        const size_t flags) const
 {
     /* render ConceptName */
@@ -170,7 +171,7 @@ OFCondition DSRWaveformTreeNode::renderHTMLContentItem(STD_NAMESPACE ostream &do
     /* render Reference */
     if (result.good())
     {
-        result = DSRWaveformReferenceValue::renderHTML(docStream, annexStream, annexNumber, flags);
+        result = DSRWaveformReferenceValue::renderHTML(docStream, annexStream, annexNumber, urlPrefixToCompositeObjects, flags);
         docStream << OFendl;
     }
     return result;

--- a/dcmsr/libsrc/dsrwavvl.cc
+++ b/dcmsr/libsrc/dsrwavvl.cc
@@ -195,10 +195,11 @@ OFCondition DSRWaveformReferenceValue::writeItem(DcmItem &dataset) const
 OFCondition DSRWaveformReferenceValue::renderHTML(STD_NAMESPACE ostream &docStream,
                                                   STD_NAMESPACE ostream &annexStream,
                                                   size_t &annexNumber,
+                                                  const std::string& urlPrefixToCompositeObjects,
                                                   const size_t flags) const
 {
     /* render reference */
-    docStream << "<a href=\"" << HTML_HYPERLINK_PREFIX_FOR_CGI;
+    docStream << "<a href=\"" << urlPrefixToCompositeObjects;
     docStream << "?waveform=" << SOPClassUID << "+" << SOPInstanceUID;
     if (!ChannelList.isEmpty())
     {


### PR DESCRIPTION
The dsr2html tool uses a hardcoded literal string as a hyperlink prefix for refrenced composite objects (images, waveforms, etc.) in rendering the Key Object Selection documents.

Replace this literal with a string argument that will be passed by a calling application / function.

@michaelonken here is a patch that would be helpful to upstream.

CC @jadh4v @fedorov

