### PR TITLE
Remove warnings for MSVC compiler

### DIFF
--- a/dcmjpls/libsrc/djcodece.cc
+++ b/dcmjpls/libsrc/djcodece.cc
@@ -1152,7 +1152,7 @@ OFCondition DJLSEncoderBase::compressCookedFrame(
 
     frameBuffer = new Uint8[buffer_size];
     framePointer = frameBuffer;
-    result = convertToUninterleaved(frameBuffer, buffer, samplesPerPixel, width, height, jls_params.bitspersample);
+    result = convertToUninterleaved(frameBuffer, buffer, OFstatic_cast(Uint16, samplesPerPixel), width, height, OFstatic_cast(Uint16, jls_params.bitspersample));
   }
 #endif
 


### PR DESCRIPTION
This commit removes:

dcmtk\dcmjpls\libsrc\djcodece.cc(1155): warning C4244: 'argument': conversion from 'int' to 'Uint16', possible loss of data
dcmtk\dcmjpls\libsrc\djcodece.cc(1155): warning C4244: 'argument': conversion from 'int' to 'Uint16', possible loss of data