### PR TITLE
Take into account PhotometricInterpretation

### DIFF
--- a/dcmimgle/libsrc/didocu.cc
+++ b/dcmimgle/libsrc/didocu.cc
@@ -93,14 +93,19 @@ DiDocument::DiDocument(DcmObject *object,
             Object = object;
         else
             DCMIMGLE_ERROR("invalid DICOM object passed to constructor (wrong class)");
-        if (Object != NULL)
-        {
+
+        if (Object != NULL) {
+            auto dataset = (Object->ident() == EVR_dataset) ? OFstatic_cast(DcmDataset*, Object) : nullptr;
+
+            if (dataset)
+                dataset->findAndGetOFString(DCM_PhotometricInterpretation, PhotometricInterpretation);
+
             // try to determine the transfer syntax from the given object
             if (Xfer == EXS_Unknown)
             {
                 // check type before casting the object
-                if (Object->ident() == EVR_dataset)
-                    Xfer = OFstatic_cast(DcmDataset *, Object)->getOriginalXfer();
+                if (dataset)
+                    Xfer = dataset->getOriginalXfer();
                 else // could only be an item
                     DCMIMGLE_WARN("can't determine original transfer syntax from given DICOM object");
             }


### PR DESCRIPTION
I have a DICOM file that can't be loaded because the PhotometricInterpreation is being cosidered correctly when the Image class is created.
[3DSlice52.zip](https://github.com/user-attachments/files/17365290/3DSlice52.zip)
