### PR TITLE
An alternative implementation to speed up iterating successive `DcmList` elements using `seek_to`

### DIFF
--- a/dcmdata/include/dcmtk/dcmdata/dclist.h
+++ b/dcmdata/include/dcmtk/dcmdata/dclist.h
@@ -171,6 +171,10 @@ private:
     /// pointer to current node in list
     DcmListNode *currentNode;
 
+    /// the current absolute position that is maintained in order to avoid O(n) lookup
+    /// when essentially iterating the elements using `seek_to`
+    unsigned long currentAbsolutePosition;
+
     /// number of elements in list
     unsigned long cardinality;
  

--- a/dcmdata/libsrc/dclist.cc
+++ b/dcmdata/libsrc/dclist.cc
@@ -171,7 +171,7 @@ DcmObject *DcmList::insert( DcmObject *obj, E_ListPos pos )
                 node->nextNode = currentNode;
                 currentNode->prevNode = node;
                 currentNode = node;
-                currentAbsolutePosition++;
+                // NB: no need to update currentAbsolutePosition
                 cardinality++;
             }
             else //( pos==ELP_next || pos==ELP_atpos )

--- a/dcmdata/tests/tsequen.cc
+++ b/dcmdata/tests/tsequen.cc
@@ -40,19 +40,31 @@ OFTEST(dcmdata_sequenceInsert)
     DcmSequenceOfItems sequence(DCM_OtherPatientIDsSequence);
     /* add a large number of items to the sequence */
     unsigned long counter = 0;
+    DcmItem* initiallyInsertedItems[NUMBER_OF_ITEMS];
     for (unsigned long i = 0; i < NUMBER_OF_ITEMS; ++i)
     {
-        if (sequence.insert(new DcmItem()).good())
+        DcmItem* item = new DcmItem();
+        initiallyInsertedItems[i] = item;
+        if (sequence.insert(item).good())
             ++counter;
     }
     /* check whether that worked (for-loop shouldn't take too long) */
     OFCHECK_EQUAL(counter, NUMBER_OF_ITEMS);
     /* access specific items (performance should be no issue) */
-    OFCHECK(sequence.getItem(0) != NULL);
-    OFCHECK(sequence.getItem(2) != NULL);
+    OFCHECK(sequence.getItem(0) == initiallyInsertedItems[0]);
+    OFCHECK(sequence.getItem(2) == initiallyInsertedItems[2]);
     OFCHECK(sequence.getItem(NUMBER_OF_ITEMS) == NULL);
-    OFCHECK(sequence.getItem(NUMBER_OF_ITEMS - 1) != NULL);
-    OFCHECK(sequence.getItem(NUMBER_OF_ITEMS - 2) != NULL);
+    OFCHECK(sequence.getItem(NUMBER_OF_ITEMS - 1) == initiallyInsertedItems[NUMBER_OF_ITEMS - 1]);
+    OFCHECK(sequence.getItem(NUMBER_OF_ITEMS - 2) == initiallyInsertedItems[NUMBER_OF_ITEMS - 2]);
+    /* insert a single item before the current item */
+    DcmItem* item = new DcmItem();
+    OFBool before = true;
+    OFCHECK(sequence.insertAtCurrentPos(item, before).good());
+    OFCHECK(sequence.getItem(NUMBER_OF_ITEMS - 2) == item);
+    /* the items after the new item should have been shifted by one */
+    OFCHECK(sequence.getItem(NUMBER_OF_ITEMS - 1) == initiallyInsertedItems[NUMBER_OF_ITEMS - 2]);
+    OFCHECK(sequence.getItem(NUMBER_OF_ITEMS) == initiallyInsertedItems[NUMBER_OF_ITEMS - 1]);
+    OFCHECK(sequence.getItem(NUMBER_OF_ITEMS + 1) == NULL);
 }
 
 


### PR DESCRIPTION
Problem: Reading a real-world DICOM image was a bit slow, and simple profiling suggested that some 50% of the time (*) was spent in `DcmPixelSequence` essentially iterating a long list using successive calls to `DcmList::seek_to` (which has a random-access-like interface, but internally _iterates_ over a doubly linked list)

Solution: In `DcmList`, keep the current absolute position, essentially catering for O(1) access whenever going to the previous or the next element (NB: truly _random_ access is still O(n), though)

(*): the other 50% was spent decoding jpeg tiles, which is legit use of time of course