### PR TITLE
Fixed compilation error

### DIFF
--- a/dcmdata/include/dcmtk/dcmdata/libi2d/i2d.h
+++ b/dcmdata/include/dcmtk/dcmdata/libi2d/i2d.h
@@ -45,7 +45,7 @@ public:
 
   /** Destructor, frees plugin memory
    */
-  ~Image2Dcm();
+  virtual ~Image2Dcm();
 
   /** Start the conversion. Needs a fully configured input plugin
    *  and a fully configured output plugin to operate. Returns


### PR DESCRIPTION
dcmtk/dcmdata/include/dcmtk/dcmdata/libi2d/i2d.h:37:24: error: ‘class Image2Dcm’ has virtual functions and accessible non-virtual destructor [-Werror=non-virtual-dtor]
   37 | class DCMTK_I2D_EXPORT Image2Dcm
      |                        ^~~~~~~~~