### PR TITLE
Rework writeBulkData API

### DIFF
--- a/dcmdata/include/dcmtk/dcmdata/dcjson.h
+++ b/dcmdata/include/dcmtk/dcmdata/dcjson.h
@@ -371,6 +371,7 @@ public:
 
     /** write an attribute as BulkDataURI.
      *  @param out output stream
+     *  @param tagkey tag key of the attribute
      *  @param len length of the attribute value
      *  @param byteValues pointer to the raw attribute value in little endian byte order
      *  @param extension file name extension
@@ -378,6 +379,7 @@ public:
      */
     virtual OFCondition writeBulkData(
         STD_NAMESPACE ostream &out,
+        const DcmTagKey& tagkey,
         Uint32 len,
         Uint8 *byteValues,
         const char *extension = ".bin");
@@ -426,7 +428,7 @@ private:
     NumStringPolicy numStringPolicy;
 
     /** minimum size of binary attributes to be written as bulk data,
-     *  in kBytes. A negative valuemeans that no bulk data is written.
+     *  in kBytes. A negative value means that no bulk data is written.
      */
     ssize_t minBulkDataSize;
 

--- a/dcmdata/libsrc/dcchrstr.cc
+++ b/dcmdata/libsrc/dcchrstr.cc
@@ -236,7 +236,7 @@ OFCondition DcmCharString::writeJson(STD_NAMESPACE ostream &out,
         {
             /* adjust byte order to little endian */
             Uint8 *byteValues = OFstatic_cast(Uint8 *, getValue(EBO_LittleEndian));
-            result = format.writeBulkData(out, getLengthField(), byteValues);
+            result = format.writeBulkData(out, getTag(), getLengthField(), byteValues);
         }
         else
         {

--- a/dcmdata/libsrc/dcelem.cc
+++ b/dcmdata/libsrc/dcelem.cc
@@ -1622,7 +1622,7 @@ OFCondition DcmElement::writeJson(STD_NAMESPACE ostream &out,
         {
             /* adjust byte order to little endian */
             Uint8 *byteValues = OFstatic_cast(Uint8 *, getValue(EBO_LittleEndian));
-            result = format.writeBulkData(out, getLengthField(), byteValues);
+            result = format.writeBulkData(out, getTag(), getLengthField(), byteValues);
         }
         else
         {

--- a/dcmdata/libsrc/dcjson.cc
+++ b/dcmdata/libsrc/dcjson.cc
@@ -307,6 +307,7 @@ void DcmJsonFormat::setBulkDir(const char *bulk_dir)
 
 OFCondition DcmJsonFormat::writeBulkData(
     STD_NAMESPACE ostream &out,
+    const DcmTagKey& /*tagkey*/,
     Uint32 len,
     Uint8 *byteValues,
     const char *extension)
@@ -363,7 +364,7 @@ OFCondition DcmJsonFormat::writeBulkData(
             }
         }
 
-        /* return defined BulkDataURI */
+        /* return defined BulkDataURI associated with `tagKey` */
         printBulkDataURIPrefix(out);
         bulkDataURI.append(bulkname);
         DcmJsonFormat::printString(out, bulkDataURI);
@@ -387,7 +388,7 @@ OFCondition DcmJsonFormat::writeBinaryAttribute(
     {
         if (asBulkDataURI(tagkey, len))
         {
-            result = writeBulkData(out, len, byteValues, extension);
+            result = writeBulkData(out, tagkey, len, byteValues, extension);
         }
         else
         {

--- a/dcmdata/libsrc/dcpixel.cc
+++ b/dcmdata/libsrc/dcpixel.cc
@@ -1323,7 +1323,7 @@ OFCondition DcmPixelData::writeJson(STD_NAMESPACE ostream &out,
             Uint8 *byteValues = OFstatic_cast(Uint8 *, getValue(EBO_LittleEndian));
 
             // write as bulk data
-            OFCondition status = format.writeBulkData(out, getLengthField(), byteValues);
+            OFCondition status = format.writeBulkData(out, getTag(), getLengthField(), byteValues);
 
             // write JSON Closer
             writeJsonCloser(out, format);

--- a/dcmdata/libsrc/dcvrds.cc
+++ b/dcmdata/libsrc/dcvrds.cc
@@ -293,7 +293,7 @@ OFCondition DcmDecimalString::writeJson(STD_NAMESPACE ostream &out,
         {
             /* adjust byte order to little endian */
             Uint8 *byteValues = OFstatic_cast(Uint8 *, getValue(EBO_LittleEndian));
-            status = format.writeBulkData(out, getLengthField(), byteValues);
+            status = format.writeBulkData(out, getTag(), getLengthField(), byteValues);
         }
         else
         {

--- a/dcmdata/libsrc/dcvrfd.cc
+++ b/dcmdata/libsrc/dcvrfd.cc
@@ -425,7 +425,7 @@ OFCondition DcmFloatingPointDouble::writeJson(STD_NAMESPACE ostream &out,
         {
             /* adjust byte order to little endian */
             Uint8 *byteValues = OFstatic_cast(Uint8 *, getValue(EBO_LittleEndian));
-            status = format.writeBulkData(out, getLengthField(), byteValues);
+            status = format.writeBulkData(out, getTag(), getLengthField(), byteValues);
         }
         else
         {

--- a/dcmdata/libsrc/dcvrfl.cc
+++ b/dcmdata/libsrc/dcvrfl.cc
@@ -427,7 +427,7 @@ OFCondition DcmFloatingPointSingle::writeJson(STD_NAMESPACE ostream &out,
         {
             /* adjust byte order to little endian */
             Uint8 *byteValues = OFstatic_cast(Uint8 *, getValue(EBO_LittleEndian));
-            status = format.writeBulkData(out, getLengthField(), byteValues);
+            status = format.writeBulkData(out, getTag(), getLengthField(), byteValues);
         }
         else
         {

--- a/dcmdata/libsrc/dcvris.cc
+++ b/dcmdata/libsrc/dcvris.cc
@@ -160,7 +160,7 @@ OFCondition DcmIntegerString::writeJson(STD_NAMESPACE ostream &out,
         {
             /* adjust byte order to little endian */
             Uint8 *byteValues = OFstatic_cast(Uint8 *, getValue(EBO_LittleEndian));
-            status = format.writeBulkData(out, getLengthField(), byteValues);
+            status = format.writeBulkData(out, getTag(), getLengthField(), byteValues);
         }
         else
         {

--- a/dcmdata/libsrc/dcvrsv.cc
+++ b/dcmdata/libsrc/dcvrsv.cc
@@ -412,7 +412,7 @@ OFCondition DcmSigned64bitVeryLong::writeJson(STD_NAMESPACE ostream &out,
         {
             /* adjust byte order to little endian */
             Uint8 *byteValues = OFstatic_cast(Uint8 *, getValue(EBO_LittleEndian));
-            status = format.writeBulkData(out, getLengthField(), byteValues);
+            status = format.writeBulkData(out, getTag(), getLengthField(), byteValues);
         }
         else
         {

--- a/dcmdata/libsrc/dcvruv.cc
+++ b/dcmdata/libsrc/dcvruv.cc
@@ -411,7 +411,7 @@ OFCondition DcmUnsigned64bitVeryLong::writeJson(STD_NAMESPACE ostream &out,
         {
             /* adjust byte order to little endian */
             Uint8 *byteValues = OFstatic_cast(Uint8 *, getValue(EBO_LittleEndian));
-            status = format.writeBulkData(out, getLengthField(), byteValues);
+            status = format.writeBulkData(out, getTag(), getLengthField(), byteValues);
         }
         else
         {


### PR DESCRIPTION
Expose the same set of parameters as the caller function writeBinaryAttribute