### PR TITLE
Streamline integration by linking socket libraries only when required

### DIFF
--- a/CMake/dcmtkPrepare.cmake
+++ b/CMake/dcmtkPrepare.cmake
@@ -726,8 +726,10 @@ function(DCMTK_TEST_SOCKET_LIBRARY NAME SYMBOL)
   endif()
 endfunction()
 
-DCMTK_TEST_SOCKET_LIBRARY(nsl "gethostbyname")
-DCMTK_TEST_SOCKET_LIBRARY(socket "socket")
+if(CMAKE_SYSTEM_NAME MATCHES "SunOS" AND CMAKE_SYSTEM_VERSION VERSION_LESS "11.4")
+  DCMTK_TEST_SOCKET_LIBRARY(nsl "gethostbyname")
+  DCMTK_TEST_SOCKET_LIBRARY(socket "socket")
+endif()
 
 #-----------------------------------------------------------------------------
 # Test if SunPro compiler and add features


### PR DESCRIPTION
DCMTK no longer unconditionally test or link against `nsl` and `socket`. These libraries are now only considered on pre-11.4 Solaris systems, where functions such as `gethostbyname` were historically provided outside libc.

On modern systems (Linux, BSD, macOS, Solaris >= 11.4), networking APIs (`gethostbyname`, `getaddrinfo`, `socket`, etc.) are provided directly by libc, so linking `-lnsl` or `-lsocket` is unnecessary.

This streamlines integration of DCMTK into external projects by removing dependencies on libraries that may directly or indirectly pull in a different OpenSSL version than the one bundled with the application.

Background:
- Solaris historically required `-lsocket -lnsl` for basic networking.
- Since Solaris 11.4, `libnsl` functionality has been folded into libc.

Verification:
- Confirmed that no `libnsl`-only symbols are referenced in DCMTK by grepping sources against the exported symbol set of `libnsl`.

References:
* https://man7.org/linux/man-pages/man3/gethostbyname.3.html
* https://man7.org/linux/man-pages/man3/getaddrinfo.3.html
* https://man7.org/linux/man-pages/man2/socket.2.html
* https://docs.oracle.com/cd/E88353_01/html/E37842/libnsl-3lib.html