### PR TITLE
Added support for Patient's Age in DSRDocument.

### DIFF
--- a/dcmsr/data/dsr2xml.xsd
+++ b/dcmsr/data/dsr2xml.xsd
@@ -91,7 +91,8 @@
         </xsd:complexType>
       </xsd:element>
       <xsd:element name="sex" type="dsr:Sex" minOccurs="0"/>
-      <!-- strictly speaking, Patient's Size and Weight belong to the Study IE -->
+      <!-- strictly speaking, Patient's Age, Size and Weight belong to the Study IE -->
+      <xsd:element name="age" type="dsr:AgeString" minOccurs="0"/>
       <xsd:element name="size" type="dsr:DecimalString" minOccurs="0"/>
       <xsd:element name="weight" type="dsr:DecimalString" minOccurs="0"/>
     </xsd:sequence>

--- a/dcmsr/include/dcmtk/dcmsr/dsrdoc.h
+++ b/dcmsr/include/dcmtk/dcmsr/dsrdoc.h
@@ -32,6 +32,7 @@
 #include "dcmtk/dcmsr/dsrrefin.h"
 #include "dcmtk/dcmsr/dsrcsidl.h"
 
+#include "dcmtk/dcmdata/dcvras.h"
 #include "dcmtk/dcmdata/dcvrcs.h"
 #include "dcmtk/dcmdata/dcvrda.h"
 #include "dcmtk/dcmdata/dcvrds.h"
@@ -536,6 +537,14 @@ class DCMTK_DCMSR_EXPORT DSRDocument
     virtual OFCondition getPatientSex(OFString &value,
                                       const signed long pos = 0) const;
 
+    /** get patient's age
+     ** @param  value  reference to variable in which the value should be stored
+     *  @param  pos    index of the value to get (0..vm-1), -1 for all components
+     ** @return status, EC_Normal if successful, an error code otherwise
+     */
+    virtual OFCondition getPatientAge(OFString &value,
+                                      const signed long pos = 0) const;
+
     /** get patient's size
      ** @param  value  reference to variable in which the value should be stored
      *  @param  pos    index of the value to get (0..vm-1), -1 for all components
@@ -810,6 +819,14 @@ class DCMTK_DCMSR_EXPORT DSRDocument
      ** @return status, EC_Normal if successful, an error code otherwise
      */
     virtual OFCondition setPatientSex(const OFString &value,
+                                      const OFBool check = OFTrue);
+
+    /** set patient's age
+     ** @param  value  value to be set (single value only) or "" for no value
+     *  @param  check  check 'value' for conformance with VR (AS) and VM (1) if enabled
+     ** @return status, EC_Normal if successful, an error code otherwise
+     */
+    virtual OFCondition setPatientAge(const OFString &value,
                                       const OFBool check = OFTrue);
 
     /** set patient's size
@@ -1412,6 +1429,8 @@ class DCMTK_DCMSR_EXPORT DSRDocument
 
     // --- Patient Study Module (U) ---
 
+    /// Patient's Age: (AS, 1, 3)
+    DcmAgeString        PatientAge;
     /// Patient's Size: (DS, 1, 3)
     DcmDecimalString    PatientSize;
     /// Patient's Weight: (DS, 1, 3)

--- a/dcmsr/tests/tsrdoc.cc
+++ b/dcmsr/tests/tsrdoc.cc
@@ -49,6 +49,9 @@ OFTEST(dcmsr_setAndGetPatientData)
     OFCHECK(doc.getPatientSex(value).good());
     OFCHECK_EQUAL(value, "M");
     /* also check some recently introduced attributes */
+    OFCHECK(doc.setPatientAge("042Y").good());
+    OFCHECK(doc.getPatientAge(value).good());
+    OFCHECK_EQUAL(value, "042Y");
     OFCHECK(doc.setPatientSize("1.88").good());
     OFCHECK(doc.getPatientSize(value).good());
     OFCHECK_EQUAL(value, "1.88");


### PR DESCRIPTION
Added support for the optional attribute Patient's Age from the Patient Study Module. The new attribute is written to and read from DICOM dataset as well as to/from the dcmsr-specific XML document format.

Also extended test case to check whether the get and set methods work as expected.