### PR TITLE
Add support for TLS encryption of C-MOVE in DcmQueryRetrieveSCP

### DIFF
--- a/dcmqrdb/include/dcmtk/dcmqrdb/dcmqrcbm.h
+++ b/dcmqrdb/include/dcmtk/dcmqrdb/dcmqrcbm.h
@@ -46,6 +46,7 @@ public:
      *  @param assoc pointer to DIMSE association
      *  @param msgid DIMSE message ID
      *  @param pr DIMSE priority
+     *  @param secureConnection a flag indicating whether or not a secure connection was requested
      */
     DcmQueryRetrieveMoveContext(
       DcmQueryRetrieveDatabaseHandle& handle,
@@ -55,7 +56,8 @@ public:
       DIC_US priorstatus,
       T_ASC_Association *assoc,
       DIC_US msgid,
-      T_DIMSE_Priority pr)
+      T_DIMSE_Priority pr,
+      OFBool secureConnection)
     : dbHandle(handle)
     , options_(options)
     , associationConfiguration_(associationConfiguration)
@@ -75,6 +77,7 @@ public:
     , nCompleted(0)
     , nFailed(0)
     , nWarning(0)
+    , secureConnection(secureConnection)
     {
       origAETitle[0] = '\0';
       origHostName[0] = '\0';
@@ -183,6 +186,8 @@ private:
     /// number of completed sub-operations that causes warnings
     DIC_US nWarning;
 
+    /// a flag indicating whether or not a secure connection was requested
+    OFBool secureConnection;
 };
 
 #endif

--- a/dcmqrdb/libsrc/dcmqrcbm.cc
+++ b/dcmqrdb/libsrc/dcmqrcbm.cc
@@ -337,6 +337,12 @@ OFCondition DcmQueryRetrieveMoveContext::buildSubAssociation(T_DIMSE_C_MoveRQ *r
         if (cond.bad()) {
             DCMQRDB_ERROR(DimseCondition::dump(temp_str, cond));
         }
+        else {
+            cond = ASC_setTransportLayerType(params, secureConnection);
+            if (cond.bad()) {
+                DCMQRDB_ERROR(DimseCondition::dump(temp_str, cond));
+            }
+        }
         DCMQRDB_DEBUG("Request Parameters:" << OFendl << ASC_dumpParameters(temp_str, params, ASC_ASSOC_RQ));
     }
     if (cond.good()) {

--- a/dcmqrdb/libsrc/dcmqrsrv.cc
+++ b/dcmqrdb/libsrc/dcmqrsrv.cc
@@ -323,7 +323,8 @@ OFCondition DcmQueryRetrieveSCP::moveSCP(T_ASC_Association * assoc, T_DIMSE_C_Mo
         T_ASC_PresentationContextID presID, DcmQueryRetrieveDatabaseHandle& dbHandle)
 {
     OFCondition cond = EC_Normal;
-    DcmQueryRetrieveMoveContext context(dbHandle, options_, associationConfiguration_, config_, STATUS_Pending, assoc, request->MessageID, request->Priority);
+    DcmQueryRetrieveMoveContext context(dbHandle, options_, associationConfiguration_, config_, STATUS_Pending, assoc, request->MessageID, request->Priority,
+        tlsOptions_.secureConnectionRequested());
 
     DIC_AE aeTitle;
     aeTitle[0] = '\0';


### PR DESCRIPTION
This PR enables TLS encryption for the C-MOVE part of the DcmQueryRetrieveSCP.