### PR TITLE
Fix TCP initialization error message if connect() or select() fails

### DIFF
--- a/dcmnet/libsrc/dulfsm.cc
+++ b/dcmnet/libsrc/dulfsm.cc
@@ -2485,6 +2485,7 @@ requestAssociationTCP(PRIVATE_NETWORKKEY ** network,
     {
         // an error other than timeout in non-blocking mode has occurred,
         // either in connect() or in select().
+        OFerror_code ec = OFStandard::getLastNetworkErrorCode();
 #ifdef HAVE_WINSOCK_H
         (void) shutdown(s,  1 /* SD_SEND */);
         (void) closesocket(s);
@@ -2496,7 +2497,7 @@ requestAssociationTCP(PRIVATE_NETWORKKEY ** network,
         (*association)->connection = NULL;
 
         OFString msg = "TCP Initialization Error: ";
-        msg += OFStandard::getLastNetworkErrorCode().message();
+        msg += ec.message();
         return makeDcmnetCondition(DULC_TCPINITERROR, OF_error, msg.c_str());
     } else {
         // success - we've opened a TCP transport connection


### PR DESCRIPTION
This fixes the following misleading error message on failed connection:
"TCP Initialization Error: No error".

To prevent that, we ought to cache error message before calling
functions that will reset last WSA error code to 0.