### PR TITLE
Fix OpenJPEG target handling in DCMTKConfig.cmake

### DIFF
--- a/CMake/DCMTKConfig.cmake.in
+++ b/CMake/DCMTKConfig.cmake.in
@@ -109,6 +109,11 @@ SET_AND_CHECK(DCMTK_TARGETS "@PACKAGE_DCMTK_CMKDIR_CONFIG@/DCMTKTargets.cmake")
 # Compatibility: This variable is deprecated
 set(DCMTK_INCLUDE_DIR ${DCMTK_INCLUDE_DIRS})
 
+include(CMakeFindDependencyMacro)
+if(DCMTK_WITH_OPENJPEG)
+  find_dependency(OpenJPEG)
+endif()
+
 if(NOT DCMTK_TARGETS_IMPORTED)
   set(DCMTK_TARGETS_IMPORTED 1)
   include(${DCMTK_TARGETS})


### PR DESCRIPTION
When DCMTK is built with OpenJPEG support, DCMTKTargets.cmake contains
INTERFACE_LINK_LIBRARIES entries that reference the imported target
openjp2. If a consuming project includes DCMTKConfig.cmake without
previously finding OpenJPEG, CMake errors out because the openjp2
target does not exist.

Use CMakeFindDependencyMacro to conditionally call find_dependency(OpenJPEG)
when DCMTK_WITH_OPENJPEG is enabled. This guarantees that the openjp2
target is defined before DCMTKTargets.cmake is processed,
while avoiding redundant lookups in projects that have already found
OpenJPEG themselves.