### PR TITLE
Add printf format attribute to OFFile printf wrappers

### DIFF
--- a/ofstd/include/dcmtk/ofstd/offile.h
+++ b/ofstd/include/dcmtk/ofstd/offile.h
@@ -47,6 +47,20 @@ END_EXTERN_C
 #undef clearerr
 #endif
 
+/* Enable compile-time checking of arguments passed to the printf-style
+ * member functions of OFFile, and mark their format parameter as a valid
+ * forwarding target so -Wformat-nonliteral does not warn inside them.
+ * FMT is the 1-based position of the format string parameter and ARGS the
+ * position of the first variadic argument (0 for va_list functions); the
+ * implicit 'this' parameter of non-static member functions counts as
+ * parameter 1.
+ */
+#if defined(__GNUC__) || defined(__clang__)
+#define OFFILE_FORMAT_PRINTF(FMT, ARGS) __attribute__((format(printf, FMT, ARGS)))
+#else
+#define OFFILE_FORMAT_PRINTF(FMT, ARGS)
+#endif
+
 /* When using the ISO C++ include files such as <cstdio>, <cstdarg> etc.,
  * all ANSI C functions like fopen() are declared in namespace std,
  * (e.g. we have to use std::fopen()), but non-ANSI Posix functions remain
@@ -884,6 +898,7 @@ public:
    *  @param ... further parameters according to format string
    *  @return number of characters printed
    */
+  OFFILE_FORMAT_PRINTF(2, 3)
   int fprintf(const char *format, ...)
   {
     int result = 0;
@@ -899,6 +914,7 @@ public:
    *  @param arg list of further parameters according to format string
    *  @return number of characters printed
    */
+   OFFILE_FORMAT_PRINTF(2, 0)
    int vfprintf(const char *format, va_list arg)
    {
      return :: vfprintf(file_, format, arg);


### PR DESCRIPTION
`OFFile::fprintf` and `OFFile::vfprintf` forward their `format` parameter to `::vfprintf`, which triggers clang/gcc `-Wformat-nonliteral` in every translation unit that includes `offile.h`.

Annotating the two wrappers with `__attribute__((format(printf, ...)))` (guarded, empty on other compilers) marks the parameter as a valid forwarding target — silencing the wrapper-internal warning — and additionally gives all callers compile-time format/argument checking.

Found while building ITK, which vendors DCMTK and compiles with `-Wformat-nonliteral` enabled.
